### PR TITLE
Fix name export

### DIFF
--- a/cv2/__init__.py
+++ b/cv2/__init__.py
@@ -4,5 +4,5 @@ import os
 # FFMPEG dll is not found on Windows without this
 os.environ["PATH"] += os.pathsep + os.path.dirname(os.path.realpath(__file__))
 
-from . import cv2
+from .cv2 import *
 sys.modules['cv2'] = cv2


### PR DESCRIPTION
Some IDEs (especially PyCharm) are not able to index module contents if `__init__.py` exports them in ways other than this (http://stackoverflow.com/questions/34365044/pycharm-does-not-recognize-cv2-as-a-module). This commit fixes the problem.