### PR TITLE
.travis.yml: Replace travis_wait with simple timer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -208,8 +208,8 @@ before_install:
 install:
     # Maybe get and clean and patch source
     - clean_code $REPO_DIR $BUILD_COMMIT
-    # Output something every 10 minutes or Travis kills the job
-    - while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
+    # Output something every 5 minutes or Travis kills the job after 10 minutes
+    - while sleep 300; do echo "=====[ $SECONDS seconds still running ]====="; done &
     - build_wheel $REPO_DIR $PLAT
     # Killing background sleep loop
     - kill %1

--- a/.travis.yml
+++ b/.travis.yml
@@ -208,7 +208,11 @@ before_install:
 install:
     # Maybe get and clean and patch source
     - clean_code $REPO_DIR $BUILD_COMMIT
-    - travis_wait 120 build_wheel $REPO_DIR $PLAT
+    # Output something every 10 minutes or Travis kills the job
+    - while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
+    - build_wheel $REPO_DIR $PLAT
+    # Killing background sleep loop
+    - kill %1
 
 script:
     - install_run $PLAT


### PR DESCRIPTION
`travis_wait` hides output when job gets killed anyway
https://travis-ci.org/skvark/opencv-python/jobs/316114042#L127