### PR TITLE
Fix crash while building opencv for OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ env:
         - "PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'"
         # pip dependencies to _test_ your project
         - TEST_DEPENDS="numpy==1.11.1"
+        # params to bdist_wheel. used to set osx build target.
+        - BDIST_PARAMS=""
 
         - PLAT=x86_64
         - UNICODE_WIDTH=32
@@ -35,6 +37,7 @@ matrix:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
+        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       language: generic
       osx_image: xcode8
@@ -42,6 +45,7 @@ matrix:
         - MB_PYTHON_VERSION=3.4
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
+        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       language: generic
       osx_image: xcode8
@@ -49,6 +53,7 @@ matrix:
         - MB_PYTHON_VERSION=3.5
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
+        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       language: generic
       osx_image: xcode8
@@ -56,6 +61,7 @@ matrix:
         - MB_PYTHON_VERSION=3.6
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
+        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       language: generic
       osx_image: xcode8
@@ -63,6 +69,8 @@ matrix:
         - MB_PYTHON_VERSION=3.7
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
+        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
+        - TEST_DEPENDS=numpy==1.14.5
 
     # headless builds for MacOS
     - os: osx
@@ -72,6 +80,7 @@ matrix:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
+        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       language: generic
       osx_image: xcode8
@@ -79,6 +88,7 @@ matrix:
         - MB_PYTHON_VERSION=3.4
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
+        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       language: generic
       osx_image: xcode8
@@ -86,6 +96,7 @@ matrix:
         - MB_PYTHON_VERSION=3.5
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
+        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       language: generic
       osx_image: xcode8
@@ -93,6 +104,7 @@ matrix:
         - MB_PYTHON_VERSION=3.6
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
+        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       language: generic
       osx_image: xcode8
@@ -100,6 +112,8 @@ matrix:
         - MB_PYTHON_VERSION=3.7
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
+        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
+        - TEST_DEPENDS=numpy==1.14.5
 
     # Contrib builds for MacOS
     - os: osx
@@ -109,6 +123,7 @@ matrix:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
+        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       language: generic
       osx_image: xcode8
@@ -116,6 +131,7 @@ matrix:
         - MB_PYTHON_VERSION=3.4
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
+        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       language: generic
       osx_image: xcode8
@@ -123,6 +139,7 @@ matrix:
         - MB_PYTHON_VERSION=3.5
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
+        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       language: generic
       osx_image: xcode8
@@ -130,6 +147,7 @@ matrix:
         - MB_PYTHON_VERSION=3.6
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
+        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       language: generic
       osx_image: xcode8
@@ -137,6 +155,8 @@ matrix:
         - MB_PYTHON_VERSION=3.7
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
+        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
+        - TEST_DEPENDS=numpy==1.14.5
 
     # headless contrib builds for MacOS
     - os: osx
@@ -146,6 +166,7 @@ matrix:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
+        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       language: generic
       osx_image: xcode8
@@ -153,6 +174,7 @@ matrix:
         - MB_PYTHON_VERSION=3.4
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
+        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       language: generic
       osx_image: xcode8
@@ -160,6 +182,7 @@ matrix:
         - MB_PYTHON_VERSION=3.5
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
+        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       language: generic
       osx_image: xcode8
@@ -167,6 +190,7 @@ matrix:
         - MB_PYTHON_VERSION=3.6
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
+        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       language: generic
       osx_image: xcode8
@@ -174,6 +198,8 @@ matrix:
         - MB_PYTHON_VERSION=3.7
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
+        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
+        - TEST_DEPENDS=numpy==1.14.5
 
     # default builds for Linux
     - os: linux

--- a/config.sh
+++ b/config.sh
@@ -14,7 +14,7 @@ function bdist_wheel_cmd {
     # copied from multibuild's common_utils.sh
     # add osx deployment target so it doesnt default to 10.6
     local abs_wheelhouse=$1
-    python setup.py bdist_wheel -- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7
+    python setup.py bdist_wheel $BDIST_PARAMS
     cp dist/*.whl $abs_wheelhouse
 }
 

--- a/config.sh
+++ b/config.sh
@@ -10,6 +10,14 @@ function build_wheel {
     build_bdist_wheel $@
 }
 
+function bdist_wheel_cmd {
+    # copied from multibuild's common_utils.sh
+    # add osx deployment target so it doesnt default to 10.6
+    local abs_wheelhouse=$1
+    python setup.py bdist_wheel -- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7
+    cp dist/*.whl $abs_wheelhouse
+}
+
 if [ -n "$IS_OSX" ]; then
   echo "    > OSX environment "
 else


### PR DESCRIPTION
The original crash was caused by scikit-build both prioritizes command line options over the parameters passed to the `setup` function, and that it defaults the command line options for `-DCMAKE_OSX_DEPLOYMENT_TARGET` and for `-DCMAKE_OSX_ARCHITECTURES` without checking that `setup` was passed those parameters. 
([this](https://github.com/scikit-build/scikit-build/blob/d8e4db57e0a930db75bd204e47b64ba83a7300bb/skbuild/setuptools_wrap.py#L468) is where scikit-build defaults the command line parameters, and [this](https://github.com/scikit-build/scikit-build/blob/d8e4db57e0a930db75bd204e47b64ba83a7300bb/skbuild/setuptools_wrap.py#L506) is where the command line parameters are combined with the passed in parameters).
As a workaround, I overrode one function in multibuild's `common_utils.sh` in `config.sh` that allows for extra command line parameters to be passed to setup.py, and set the parameters only for OSX tests in `.travis.yml`.
Also fix a later crash where `install_run` crashed on OSX builds with Python 3.7, where the `TEST_DEPENDS` environment variable defaulted to `numpy==1.11.1` where Python 3.7 requires `numpy==1.14.5`. 