### PR TITLE
Eliminate entry duplication and tilde in PATH

### DIFF
--- a/docker/Dockerfile_i686
+++ b/docker/Dockerfile_i686
@@ -84,4 +84,4 @@ RUN curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/uapi/
 	curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/linux/compiler.h && \
 	mv videodev2.h v4l2-common.h v4l2-controls.h compiler.h /usr/include/linux
 
-ENV PATH "$PATH=~/bin:$PATH"
+ENV PATH "$HOME/bin:$PATH"

--- a/docker/Dockerfile_x86_64
+++ b/docker/Dockerfile_x86_64
@@ -84,4 +84,4 @@ RUN curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/uapi/
 	curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/linux/compiler.h && \
 	mv videodev2.h v4l2-common.h v4l2-controls.h compiler.h /usr/include/linux
 
-ENV PATH "$PATH=~/bin:$PATH"
+ENV PATH "$HOME/bin:$PATH"


### PR DESCRIPTION
Currently, `PATH` in Docker images looks like this: `/usr/kerberos/sbin:/usr/kerberos/bin:/opt/Qt4.8.7/bin:/opt/rh/devtoolset-2/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin=~/bin:/opt/Qt4.8.7/bin:/opt/rh/devtoolset-2/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/bin`