### PR TITLE
Clear yum metadata in x32 docker

### DIFF
--- a/docker/Dockerfile_i686
+++ b/docker/Dockerfile_i686
@@ -84,4 +84,6 @@ RUN curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/uapi/
 	curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/linux/compiler.h && \
 	mv videodev2.h v4l2-common.h v4l2-controls.h compiler.h /usr/include/linux
 
+RUN yum clean all
+
 ENV PATH "$HOME/bin:$PATH"


### PR DESCRIPTION
Closes https://github.com/skvark/opencv-python/issues/148.

I've tried rebuilding the Docker image, and the problem persists. So `yum clean` it is.

The problem doesn't happen (as of now) in the x64 docker image. Maybe it has something to do with x32 emulation, who knows.

**After merging this and https://github.com/skvark/opencv-python/pull/149, revert https://github.com/native-api/opencv-python/commit/8aaff83a74175efbd697c287035350295d6e5b92`.** (I cannot do that here because the reverse commit is only applicable to https://github.com/native-api/opencv-python/tree/use_ccache.)