### PR TITLE
Fix OSX builds and migrate to Xcode 8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -586,9 +586,10 @@ before_install: |
         fi
         find "$TAPS" -type d -name .git -exec \
                 bash -xec '
-                    cd $(dirname '\''{}'\'')
-                    git clean -fxd
-                    git status' \;
+                    cd $(dirname '\''{}'\'') || echo "status: $?"
+                    git clean -fxd || echo "status: $?"
+                    sleep 1 || echo "status: $?"
+                    git status || echo "status: $?"' \; || echo "status: $?"
 
         brew_cache_cleanup
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ matrix:
 
     # default builds for MacOS
     - os: osx
-      language: generic
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=2.7
@@ -48,7 +47,6 @@ matrix:
         - ENABLE_HEADLESS=0
         - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
-      language: generic
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.4
@@ -56,7 +54,6 @@ matrix:
         - ENABLE_HEADLESS=0
         - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
-      language: generic
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.5
@@ -64,7 +61,6 @@ matrix:
         - ENABLE_HEADLESS=0
         - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
-      language: generic
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.6
@@ -72,7 +68,6 @@ matrix:
         - ENABLE_HEADLESS=0
         - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
-      language: generic
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.7
@@ -83,7 +78,6 @@ matrix:
 
     # headless builds for MacOS
     - os: osx
-      language: generic
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=2.7
@@ -91,7 +85,6 @@ matrix:
         - ENABLE_HEADLESS=1
         - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
-      language: generic
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.4
@@ -99,7 +92,6 @@ matrix:
         - ENABLE_HEADLESS=1
         - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
-      language: generic
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.5
@@ -107,7 +99,6 @@ matrix:
         - ENABLE_HEADLESS=1
         - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
-      language: generic
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.6
@@ -115,7 +106,6 @@ matrix:
         - ENABLE_HEADLESS=1
         - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
-      language: generic
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.7
@@ -126,7 +116,6 @@ matrix:
 
     # Contrib builds for MacOS
     - os: osx
-      language: generic
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=2.7
@@ -134,7 +123,6 @@ matrix:
         - ENABLE_HEADLESS=0
         - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
-      language: generic
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.4
@@ -142,7 +130,6 @@ matrix:
         - ENABLE_HEADLESS=0
         - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
-      language: generic
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.5
@@ -150,7 +137,6 @@ matrix:
         - ENABLE_HEADLESS=0
         - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
-      language: generic
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.6
@@ -158,7 +144,6 @@ matrix:
         - ENABLE_HEADLESS=0
         - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
-      language: generic
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.7
@@ -169,7 +154,6 @@ matrix:
 
     # headless contrib builds for MacOS
     - os: osx
-      language: generic
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=2.7
@@ -177,7 +161,6 @@ matrix:
         - ENABLE_HEADLESS=1
         - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
-      language: generic
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.4
@@ -185,7 +168,6 @@ matrix:
         - ENABLE_HEADLESS=1
         - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
-      language: generic
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.5
@@ -193,7 +175,6 @@ matrix:
         - ENABLE_HEADLESS=1
         - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
-      language: generic
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.6
@@ -201,7 +182,6 @@ matrix:
         - ENABLE_HEADLESS=1
         - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
-      language: generic
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,38 +33,38 @@ cache:
     - $HOME/local_bottle_metadata
     # `cache: ccache: true` has no effect if `language:` is not `c` or `cpp`
     - $HOME/.ccache
-    
+
 matrix:
   fast_finish: true
   include:
 
     # default builds for MacOS
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.4
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.5
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.6
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.7
         - ENABLE_CONTRIB=0
@@ -73,31 +73,31 @@ matrix:
 
     # headless builds for MacOS
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.4
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.5
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.6
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.7
         - ENABLE_CONTRIB=0
@@ -106,31 +106,31 @@ matrix:
 
     # Contrib builds for MacOS
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.4
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.5
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.6
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.7
         - ENABLE_CONTRIB=1
@@ -139,31 +139,31 @@ matrix:
 
     # headless contrib builds for MacOS
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.4
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.5
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.6
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.7
         - ENABLE_CONTRIB=1
@@ -578,7 +578,7 @@ before_install: |
     source multibuild_customize.sh
     echo $ENABLE_CONTRIB > contrib.enabled
     echo $ENABLE_HEADLESS > headless.enabled
-    
+
     if [ -n "$IS_OSX" ]; then
         TAPS="$(brew --repository)/Library/Taps"
         if [ -e "$TAPS/caskroom/homebrew-cask" -a -e "$TAPS/homebrew/homebrew-cask" ]; then
@@ -589,10 +589,10 @@ before_install: |
                     cd $(dirname '\''{}'\'')
                     git clean -fxd
                     git status' \;
-                    
+
         brew_cache_cleanup
     fi
-    
+
     before_install
     # Not interested in travis internal scripts' output
     set +x
@@ -613,7 +613,7 @@ script: |
     #otherwise, Travis logic terminates prematurely
     #https://travis-ci.community/t/shell-session-update-command-not-found-in-build-log-causes-build-to-fail-if-trap-err-is-set/817
     trap ERR
-    
+
     test "$rc" -eq 0
 
 before_cache: |
@@ -627,10 +627,10 @@ before_cache: |
         fi
 
         brew_cache_cleanup
-        
+
     fi
     set +x
-    
+
 after_success: |
     # Upload wheels to pypi if requested
     if [ -n "$TRAVIS_TAG" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,144 +34,232 @@ cache:
     # `cache: ccache: true` has no effect if `language:` is not `c` or `cpp`
     - $HOME/.ccache
 
+# Add more cache stages (s2 etc) and corresponding OSX jobs like s1
+# if brew builds start to take longer than one Travis time limit
+stages:
+  - s1
+  - final
+    
 matrix:
   fast_finish: true
   include:
 
     # default builds for MacOS
-    - os: osx
+    - &osx-10
+      os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
-    - os: osx
+      stage: final
+    - <<: *osx-10
+      stage: s1
+    - &osx-30
+      os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.4
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
-    - os: osx
+      stage: final
+    - <<: *osx-30
+      stage: s1
+    - &osx-40
+      os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.5
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
-    - os: osx
+      stage: final
+    - <<: *osx-40
+      stage: s1
+    - &osx-50
+      os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.6
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
-    - os: osx
+      stage: final
+    - <<: *osx-50
+      stage: s1
+    - &osx-60
+      os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.7
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
         - TEST_DEPENDS=numpy==1.14.5
+      stage: final
+    - <<: *osx-60
+      stage: s1
 
     # headless builds for MacOS
-    - os: osx
+    - &osx-70
+      os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
-    - os: osx
+      stage: final
+    - <<: *osx-70
+      stage: s1
+    - &osx-80
+      os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.4
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
-    - os: osx
+      stage: final
+    - <<: *osx-80
+      stage: s1
+    - &osx-90
+      os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.5
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
-    - os: osx
+      stage: final
+    - <<: *osx-90
+      stage: s1
+    - &osx-100
+      os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.6
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
-    - os: osx
+      stage: final
+    - <<: *osx-100
+      stage: s1
+    - &osx-110
+      os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.7
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
         - TEST_DEPENDS=numpy==1.14.5
+      stage: final
+    - <<: *osx-110
+      stage: s1
 
     # Contrib builds for MacOS
-    - os: osx
+    - &osx-120
+      os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
-    - os: osx
+      stage: final
+    - <<: *osx-120
+      stage: s1
+    - &osx-130
+      os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.4
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
-    - os: osx
+      stage: final
+    - <<: *osx-130
+      stage: s1
+    - &osx-140
+      os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.5
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
-    - os: osx
+      stage: final
+    - <<: *osx-140
+      stage: s1
+    - &osx-150
+      os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.6
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
-    - os: osx
+      stage: final
+    - <<: *osx-150
+      stage: s1
+    - &osx-160
+      os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.7
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
         - TEST_DEPENDS=numpy==1.14.5
+      stage: final
+    - <<: *osx-160
+      stage: s1
 
     # headless contrib builds for MacOS
-    - os: osx
+    - &osx-170
+      os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
-    - os: osx
+      stage: final
+    - <<: *osx-170
+      stage: s1
+    - &osx-180
+      os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.4
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
-    - os: osx
+      stage: final
+    - <<: *osx-180
+      stage: s1
+    - &osx-190
+      os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.5
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
-    - os: osx
+      stage: final
+    - <<: *osx-190
+      stage: s1
+    - &osx-200
+      os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.6
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
-    - os: osx
+      stage: final
+    - <<: *osx-200
+      stage: s1
+    - &osx-210
+      os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.7
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
         - TEST_DEPENDS=numpy==1.14.5
+      stage: final
+    - <<: *osx-210
+      stage: s1
 
     # default builds for Linux
     - os: linux
+      # the following jobs will use the same stage name by default
+      stage: s1
       env:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -619,7 +619,7 @@ script: |
 
 before_cache: |
     # Cleanup dirs to be cached
-    set -x
+    set -e; set -x
     if [ -n "$IS_OSX" ]; then
 
         # When Taps is cached, this dir causes "Error: file exists" on `brew update`
@@ -630,7 +630,7 @@ before_cache: |
         brew_cache_cleanup
 
     fi
-    set +x
+    set +x; set +e
 
 after_success: |
     # Upload wheels to pypi if requested

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,35 +45,30 @@ matrix:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
-        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.4
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
-        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.5
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
-        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.6
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
-        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.7
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
-        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
         - TEST_DEPENDS=numpy==1.14.5
 
     # headless builds for MacOS
@@ -83,35 +78,30 @@ matrix:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
-        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.4
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
-        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.5
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
-        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.6
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
-        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.7
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
-        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
         - TEST_DEPENDS=numpy==1.14.5
 
     # Contrib builds for MacOS
@@ -121,35 +111,30 @@ matrix:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
-        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.4
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
-        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.5
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
-        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.6
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
-        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.7
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
-        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
         - TEST_DEPENDS=numpy==1.14.5
 
     # headless contrib builds for MacOS
@@ -159,35 +144,30 @@ matrix:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
-        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.4
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
-        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.5
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
-        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.6
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
-        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
     - os: osx
       osx_image: xcode8
       env:
         - MB_PYTHON_VERSION=3.7
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
-        - BDIST_PARAMS="-- -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7"
         - TEST_DEPENDS=numpy==1.14.5
 
     # default builds for Linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -594,7 +594,6 @@ before_install: |
         brew_cache_cleanup
     fi
 
-    before_install
     # Not interested in travis internal scripts' output
     set +x
 
@@ -602,7 +601,6 @@ install: |
     # Build and package
     set -x
     build_wheel $REPO_DIR $PLAT
-    if [ -n "$USE_CCACHE" ]; then ccache --show-stats; fi
     set +x
 
 script: |

--- a/config.sh
+++ b/config.sh
@@ -95,11 +95,6 @@ function pre_build {
         brew_add_local_bottles
     fi
 
-    # Don't query analytical info online on `brew info`,
-    #  this takes several seconds and we don't need it
-    # see https://docs.brew.sh/Manpage , "info formula" section
-    export HOMEBREW_NO_GITHUB_API=1
-
     echo 'Installing QT4'
     brew tap | grep -qxF cartr/qt4 || brew tap cartr/qt4
     brew tap --list-pinned | grep -qxF cartr/qt4 || brew tap-pin cartr/qt4

--- a/config.sh
+++ b/config.sh
@@ -32,7 +32,6 @@ if [ -n "$IS_OSX" ]; then
     source travis_osx_brew_cache.sh
 
     BREW_SLOW_BUILIDING_PACKAGES=$(printf '%s\n' \
-        "x265 20"  \
         "cmake 15" \
         "ffmpeg_opencv 10" \
     )

--- a/config.sh
+++ b/config.sh
@@ -70,8 +70,8 @@ if [ -n "$IS_OSX" ]; then
                 if (!$found_blank && /^$/) {$_.="conflicts_with \"ffmpeg\"\n\n"; $found_blank=1; next;}
                 if (!$bottle_block && /^\s*bottle do$/) { $bottle_block=1; next; }
                 if ($bottle_block) { if (/^\s*end\s*$/) { $bottle_block=0} elsif (/^\s*sha256\s/) {$_=""} next; }
-if (/^\s*depends_on "(x264|x265|xvid)"$/) {$_=""; next;}
-                if (/^\s*--enable-(gpl|libx264|libx265|libxvid)$/) {$_=""; next;}
+if (/^\s*depends_on "(x264|x265|xvid|frei0r|rubberband)"$/) {$_=""; next;}
+                if (/^\s*--enable-(gpl|libx264|libx265|libxvid|frei0r|librubberband)$/) {$_=""; next;}
                 ' <"$FF_FORMULA" >"$LFF_FORMULA"
             diff -u "$FF_FORMULA" "$LFF_FORMULA" || test $? -le 1
 

--- a/config.sh
+++ b/config.sh
@@ -92,14 +92,14 @@ function pre_build {
   if [ -n "$IS_OSX" ]; then
     echo "Running for OSX"
 
-    brew update --force
+    brew update
     brew_add_local_bottles
 
     # Don't query analytical info online on `brew info`,
     #  this takes several seconds and we don't need it
     # see https://docs.brew.sh/Manpage , "info formula" section
     export HOMEBREW_NO_GITHUB_API=1
-
+    
     echo 'Installing QT4'
     brew tap | grep -qxF cartr/qt4 || brew tap cartr/qt4
     brew tap --list-pinned | grep -qxF cartr/qt4 || brew tap-pin cartr/qt4

--- a/setup.py
+++ b/setup.py
@@ -268,7 +268,7 @@ class RearrangeCMakeOutput(object):
 
         # 'relpath'/'reldir' = relative to CMAKE_INSTALL_DIR/cmake_install_dir
         # 'path'/'dir' = relative to sourcetree root
-        cmake_install_dir = os.path.join(cls._setuptools_wrap.CMAKE_INSTALL_DIR,
+        cmake_install_dir = os.path.join(cls._setuptools_wrap.CMAKE_INSTALL_DIR(),
                                          cmake_install_reldir)
         install_relpaths = [os.path.relpath(p, cmake_install_dir) for p in install_paths]
         fslash_install_relpaths = [p.replace(os.path.sep, '/') for p in install_relpaths]

--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,7 @@ def main():
         cmake_args.append("-DWITH_LAPACK=OFF")  # Some OSX LAPACK fns are incompatible, see
                                                 # https://github.com/skvark/opencv-python/issues/21
         cmake_args.append("-DCMAKE_CXX_FLAGS=-stdlib=libc++")
+        cmake_args.append("-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.7")
 
     if sys.platform.startswith('linux'):
         cmake_args.append("-DWITH_IPP=OFF")   # tests fail with IPP compiled with

--- a/setup.py
+++ b/setup.py
@@ -102,12 +102,16 @@ def main():
         # skbuild inserts PYTHON_* vars. That doesn't satisfy opencv build scripts in case of Py3
         "-DPYTHON%d_EXECUTABLE=%s" % (sys.version_info[0], sys.executable),
         "-DBUILD_opencv_python%d=ON" % sys.version_info[0],
+        
+        # When off, adds __init__.py and a few more helper .py's. We use our own helper files with a different structure.
         "-DOPENCV_SKIP_PYTHON_LOADER=ON",
-        "-DOPENCV_PYTHON2_INSTALL_PATH=python",
-        "-DOPENCV_PYTHON3_INSTALL_PATH=python",
+        # Relative dir to install the built module to in the build tree.
+        # The default is generated from sysconfig, we'd rather have a constant for simplicity
+        "-DOPENCV_PYTHON%d_INSTALL_PATH=python" % sys.version_info[0],
         # Otherwise, opencv scripts would want to install `.pyd' right into site-packages,
         # and skbuild bails out on seeing that
         "-DINSTALL_CREATE_DISTRIB=ON",
+        
         # See opencv/CMakeLists.txt for options and defaults
         "-DBUILD_opencv_apps=OFF",
         "-DBUILD_SHARED_LIBS=OFF",

--- a/travis_osx_brew_cache.sh
+++ b/travis_osx_brew_cache.sh
@@ -22,6 +22,12 @@ BREW_TIME_HARD_LIMIT=$((43*60))
 # when the caching logic isn't prepared for that
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
+# Don't query analytical info online on `brew info`,
+#  this takes several seconds and we don't need it
+# see https://docs.brew.sh/Manpage , "info formula" section
+export HOMEBREW_NO_GITHUB_API=1
+
+
 
 
 #Public functions

--- a/travis_osx_brew_cache.sh
+++ b/travis_osx_brew_cache.sh
@@ -11,11 +11,11 @@ BREW_TIME_START=$(($TRAVIS_TIMER_START_TIME/10**9))
 # If after a package is built, elapsed time is more than this many seconds, fail the build but save Travis cache
 # The cutoff moment should leave enough time till Travis' job time limit to process the main project.
 #  Since we have moved deps into a separate stage, we don't need to leave time for the project any more
-BREW_TIME_LIMIT=$((38*60))
+BREW_TIME_LIMIT=$((42*60))
 # If a slow-building package is about to be built and the projected build end moment is beyond this many seconds,
 # skip that build, fail the Travis job and save Travis cache.
 # This cutoff should leave enough time for before_cache and cache save.
-BREW_TIME_HARD_LIMIT=$((40*60))
+BREW_TIME_HARD_LIMIT=$((43*60))
 
 
 # Auto cleanup can delete locally-built bottles

--- a/travis_osx_brew_cache.sh
+++ b/travis_osx_brew_cache.sh
@@ -10,7 +10,8 @@ BREW_TIME_START=$(($TRAVIS_TIMER_START_TIME/10**9))
 
 # If after a package is built, elapsed time is more than this many seconds, fail the build but save Travis cache
 # The cutoff moment should leave enough time till Travis' job time limit to process the main project.
-BREW_TIME_LIMIT=$((30*60))
+#  Since we have moved deps into a separate stage, we don't need to leave time for the project any more
+BREW_TIME_LIMIT=$((38*60))
 # If a slow-building package is about to be built and the projected build end moment is beyond this many seconds,
 # skip that build, fail the Travis job and save Travis cache.
 # This cutoff should leave enough time for before_cache and cache save.
@@ -207,6 +208,7 @@ function brew_cache_cleanup {
 function brew_go_bootstrap_mode {
 # Can be overridden
 # Terminate the build but ensure saving the cache
+    local EXIT_CODE=${1:-1}
 
     echo "Going into cache bootstrap mode"
     
@@ -223,7 +225,7 @@ function brew_go_bootstrap_mode {
         
         # Travis runs user scripts via `eval` i.e. in the same shell process.
         # So have to unset errexit in order to get to cache save stage
-        set +e; return 1
+        set +e; return '"$EXIT_CODE"'
     }'    
 }
 

--- a/travis_osx_brew_cache.sh
+++ b/travis_osx_brew_cache.sh
@@ -215,6 +215,8 @@ function brew_go_bootstrap_mode {
 # Terminate the build but ensure saving the cache
 
     echo "Going into cache bootstrap mode"
+    
+    BREW_BOOTSTRAP_MODE=1
         
     #Can't just `exit` because that would terminate the build without saving the cache
     #Have to replace further actions with no-ops


### PR DESCRIPTION
Subj. Major changes to react to are:

* In OSX 10.12, Homebrew has a new kind of dependency tracking -- "runtime dependency". E.g. [upgrading `openssl` would now lead to upgrading more than 60 packages linked against the old version](https://discourse.brew.sh/t/can-i-install-a-new-version-without-having-to-upgrade-runtime-dependents/4443).
    * Using [a different bottle install technique](https://discourse.brew.sh/t/can-i-install-a-new-version-without-having-to-upgrade-runtime-dependents/4443/9?u=native-api) now to install new versions alongside the old ones to avoid that.
* Python is now one of `ffmpeg`'s dependencies (indirectly) and its update conflicts with multibuild-installed python. Moreover, Homebrew upgrades the installed Py2 to Py3 as the "default" python.
    * Moved multibuild python installation to after brew build to compensate.
* Newer FFmpeg `brew` formula has more GPLed components.

Other changes are:

* Using Travis build stages to build OSX brew bottles. Now manual job restarts are not needed.

(I also see that you never regenerated x86 Docker images as promised. So Linux x86 builds still run without ccache.)