### PR TITLE
Travis CI: Xenial is now the default Ubuntu in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,9 @@ env:
 
 # Host Python is never used
 language: generic
-# Required to invoke docker ourselves as per https://docs.travis-ci.com/user/docker/
-sudo: required
 services: docker
-# https://docs.travis-ci.com/user/reference/trusty/
-dist: trusty
+# https://docs.travis-ci.com/user/reference/xenial
+dist: xenial
 
 # Save some time, we and setup check them out on demand instead
 # https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth


### PR DESCRIPTION
https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment

Also: __sudo: required__ no longer is [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration) because the sudo command is always available in Travis CI and there is no longer any way to turn it off.