### PR TITLE
Use Travis workspaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -239,8 +239,6 @@ matrix:
 
     # default builds for Linux
     - os: linux
-      # the following jobs will use the same stage name by default
-      stage: s1
       env:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,17 @@ matrix:
             - /usr/local/Homebrew/
             # used in OSX custom build script dealing with local bottle caching
             - $HOME/local_bottle_metadata
+      #workspaces share within the same build, cache shares between builds
+      cache:
+        directories:
+          # `cache: ccache: true` has no effect if `language:` is not `c` or `cpp`
+          - $HOME/.ccache
+          # https://stackoverflow.com/questions/39930171/cache-brew-builds-with-travis-ci
+          - $HOME/Library/Caches/Homebrew
+          - /usr/local/Homebrew/
+          # used in OSX custom build script dealing with local bottle caching
+          - $HOME/local_bottle_metadata
+
     # default builds for MacOS
       #further jobs in the list will use the same stage until the next assignment
     - stage: final

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,6 @@ git:
 # https://docs.travis-ci.com/user/caching
 cache:
   directories:
-    # https://stackoverflow.com/questions/39930171/cache-brew-builds-with-travis-ci
-    - $HOME/Library/Caches/Homebrew
-    - /usr/local/Homebrew/
-    # used in OSX custom build script dealing with local bottle caching
-    - $HOME/local_bottle_metadata
     # `cache: ccache: true` has no effect if `language:` is not `c` or `cpp`
     - $HOME/.ccache
 
@@ -45,217 +40,191 @@ matrix:
   fast_finish: true
   include:
 
+    - os: osx
+      osx_image: xcode8.3
+      stage: s1
+      workspaces:
+        create:
+          name: brew_cache
+          paths:
+            # https://stackoverflow.com/questions/39930171/cache-brew-builds-with-travis-ci
+            - $HOME/Library/Caches/Homebrew
+            - /usr/local/Homebrew/
+            # used in OSX custom build script dealing with local bottle caching
+            - $HOME/local_bottle_metadata
     # default builds for MacOS
-    - &osx-10
+      #further jobs in the list will use the same stage until the next assignment
+    - stage: final
       os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
-      stage: final
-    - <<: *osx-10
-      stage: s1
-    - &osx-30
-      os: osx
+      workspaces:
+        use: brew_cache
+    - os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.4
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
-      stage: final
-    - <<: *osx-30
-      stage: s1
-    - &osx-40
-      os: osx
+      workspaces:
+        use: brew_cache
+    - os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.5
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
-      stage: final
-    - <<: *osx-40
-      stage: s1
-    - &osx-50
-      os: osx
+      workspaces:
+        use: brew_cache
+    - os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.6
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
-      stage: final
-    - <<: *osx-50
-      stage: s1
-    - &osx-60
-      os: osx
+      workspaces:
+        use: brew_cache
+    - os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.7
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=0
         - TEST_DEPENDS=numpy==1.14.5
-      stage: final
-    - <<: *osx-60
-      stage: s1
+      workspaces:
+        use: brew_cache
 
     # headless builds for MacOS
-    - &osx-70
-      os: osx
+    - os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
-      stage: final
-    - <<: *osx-70
-      stage: s1
-    - &osx-80
-      os: osx
+      workspaces:
+        use: brew_cache
+    - os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.4
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
-      stage: final
-    - <<: *osx-80
-      stage: s1
-    - &osx-90
-      os: osx
+      workspaces:
+        use: brew_cache
+    - os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.5
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
-      stage: final
-    - <<: *osx-90
-      stage: s1
-    - &osx-100
-      os: osx
+      workspaces:
+        use: brew_cache
+    - os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.6
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
-      stage: final
-    - <<: *osx-100
-      stage: s1
-    - &osx-110
-      os: osx
+      workspaces:
+        use: brew_cache
+    - os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.7
         - ENABLE_CONTRIB=0
         - ENABLE_HEADLESS=1
         - TEST_DEPENDS=numpy==1.14.5
-      stage: final
-    - <<: *osx-110
-      stage: s1
+      workspaces:
+        use: brew_cache
 
     # Contrib builds for MacOS
-    - &osx-120
-      os: osx
+    - os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
-      stage: final
-    - <<: *osx-120
-      stage: s1
-    - &osx-130
-      os: osx
+      workspaces:
+        use: brew_cache
+    - os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.4
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
-      stage: final
-    - <<: *osx-130
-      stage: s1
-    - &osx-140
-      os: osx
+      workspaces:
+        use: brew_cache
+    - os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.5
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
-      stage: final
-    - <<: *osx-140
-      stage: s1
-    - &osx-150
-      os: osx
+      workspaces:
+        use: brew_cache
+    - os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.6
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
-      stage: final
-    - <<: *osx-150
-      stage: s1
-    - &osx-160
-      os: osx
+      workspaces:
+        use: brew_cache
+    - os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.7
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=0
         - TEST_DEPENDS=numpy==1.14.5
-      stage: final
-    - <<: *osx-160
-      stage: s1
+      workspaces:
+        use: brew_cache
 
     # headless contrib builds for MacOS
-    - &osx-170
-      os: osx
+    - os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=2.7
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
-      stage: final
-    - <<: *osx-170
-      stage: s1
-    - &osx-180
-      os: osx
+      workspaces:
+        use: brew_cache
+    - os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.4
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
-      stage: final
-    - <<: *osx-180
-      stage: s1
-    - &osx-190
-      os: osx
+      workspaces:
+        use: brew_cache
+    - os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.5
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
-      stage: final
-    - <<: *osx-190
-      stage: s1
-    - &osx-200
-      os: osx
+      workspaces:
+        use: brew_cache
+    - os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.6
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
-      stage: final
-    - <<: *osx-200
-      stage: s1
-    - &osx-210
-      os: osx
+      workspaces:
+        use: brew_cache
+    - os: osx
       osx_image: xcode8.3
       env:
         - MB_PYTHON_VERSION=3.7
         - ENABLE_CONTRIB=1
         - ENABLE_HEADLESS=1
         - TEST_DEPENDS=numpy==1.14.5
-      stage: final
-    - <<: *osx-210
-      stage: s1
+      workspaces:
+        use: brew_cache
 
     # default builds for Linux
     - os: linux


### PR DESCRIPTION
[A new Travis CI feature, workspaces](https://docs.travis-ci.com/user/using-workspaces/), allows to use one MacOS cache job to build FFMpeg instead of 20.

It's currently in beta -- so it's your call whether it's good enough for production use. [It worked for me well](https://travis-ci.org/native-api/opencv-python/builds/560299543) save for a [small nitpick](https://travis-ci.community/t/introducing-workspaces/4249/3?u=native-api) when I used this project to try it out.