### PR TITLE
Added OpenSSL & various protocol support to FFmpeg backend

### DIFF
--- a/docker/Dockerfile_i686
+++ b/docker/Dockerfile_i686
@@ -1,5 +1,7 @@
 FROM quay.io/pypa/manylinux1_i686:latest
 
+ENTRYPOINT ["linux32", "--"]
+
 RUN curl -O -L https://download.qt.io/archive/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz && \
 	tar -xf qt-everywhere-opensource-src-4.8.7.tar.gz && \
 	cd qt-everywhere* && \

--- a/docker/Dockerfile_i686
+++ b/docker/Dockerfile_i686
@@ -1,7 +1,5 @@
 FROM quay.io/pypa/manylinux1_i686:latest
 
-ENTRYPOINT ["linux32", "--"]
-
 RUN curl -O -L https://download.qt.io/archive/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz && \
 	tar -xf qt-everywhere-opensource-src-4.8.7.tar.gz && \
 	cd qt-everywhere* && \
@@ -16,56 +14,71 @@ ENV QTDIR /opt/Qt4.8.7
 ENV PATH "$QTDIR/bin:$PATH"
 
 RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz && \
-	tar -zxf cmake-3.9.0.tar.gz && \
+	tar -xf cmake-3.9.0.tar.gz && \
 	cd cmake-3.9.0 && \
-	yum -y install curl-devel zlib-devel && \
+    true '#manylinux1 provides curl-devel equivalent and libcurl statically linked \
+         against the same newer OpenSSL as other source-built tools \
+         (1.0.2s as of this writing)' && \
+	yum -y install zlib-devel && \
 	./configure --system-curl && \
 	make -j4 && \
 	make install && \
 	cd .. && \
 	rm -rf cmake-3.9.0*
 
-RUN	yum install autoconf automake bzip2 git freetype-devel gcc gcc-c++ libtool make pkgconfig -y && \
-    curl -O -L https://www.cpan.org/src/5.0/perl-5.20.1.tar.gz && \
-	tar -xzf perl-5.20.1.tar.gz && \
+# https://trac.ffmpeg.org/wiki/CompilationGuide/Centos#GettheDependencies
+# manylinux provides the toolchain and git; we provide cmake
+RUN yum install freetype-devel bzip2-devel zlib-devel -y && \
+    mkdir ~/ffmpeg_sources
+
+# Newer openssl configure requires newer perl
+RUN curl -O -L https://www.cpan.org/src/5.0/perl-5.20.1.tar.gz && \
+	tar -xf perl-5.20.1.tar.gz && \
 	cd perl-5.20.1 && \
-	./Configure -des -Dprefix="$HOME/ffmpeg_build" && \
-	make -j4 && \
-	make install && \
+	./Configure -des -Dprefix="$HOME/openssl_build" && \
+	true '#perl build scripts do much redundant work \
+	     if running "make install" separately' && \
+	make install -j4 && \
 	cd .. && \
 	rm -rf perl-5.20.1*
 
-RUN	yum remove nasm -y && \
-	mkdir ~/ffmpeg_sources && \
-	cd ~/ffmpeg_sources && \
+RUN cd ~/ffmpeg_sources && \
+	curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1c.tar.gz && \
+	tar -xf OpenSSL_1_1_1c.tar.gz && \
+	cd openssl-OpenSSL_1_1_1c && \
+    true '#in i686, ./config detects x64 in i686 without linux32 \
+         when run from "docker build"' && \
+	PERL="$HOME/openssl_build/bin/perl" linux32 ./config --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
+	make -j4 && \
+    true '#skip installing documentation' && \
+	make install_sw && \
+    rm -rf ~/openssl_build
+
+RUN cd ~/ffmpeg_sources && \
 	curl -O -L http://www.nasm.us/pub/nasm/releasebuilds/2.13.02/nasm-2.13.02.tar.bz2 && \
-	tar xjvf nasm-2.13.02.tar.bz2 && cd nasm-2.13.02 && ./autogen.sh && \
+	tar -xf nasm-2.13.02.tar.bz2 && cd nasm-2.13.02 && ./autogen.sh && \
 	./configure --prefix="$HOME/ffmpeg_build" --bindir="$HOME/bin" && \
 	make -j4 && \
-	make install && \
-	cd ~/ffmpeg_sources && \
+	make install
+
+RUN cd ~/ffmpeg_sources && \
 	curl -O -L http://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz && \
-	tar xzvf yasm-1.3.0.tar.gz && \
+	tar -xf yasm-1.3.0.tar.gz && \
 	cd yasm-1.3.0 && \
 	./configure --prefix="$HOME/ffmpeg_build" --bindir="$HOME/bin" && \
 	make -j4 && \
-	make install && \
-	cd ~/ffmpeg_sources && \
+	make install
+
+RUN cd ~/ffmpeg_sources && \
 	git clone --depth 1 https://chromium.googlesource.com/webm/libvpx.git && \
 	cd libvpx && \
 	./configure --prefix="$HOME/ffmpeg_build" --disable-examples --disable-unit-tests --enable-vp9-highbitdepth --as=yasm --enable-pic --enable-shared && \
 	make -j4 && \
-	make install && \
-	cd ~/ffmpeg_sources && \
-	curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1c.tar.gz && \
-	tar -zxvf OpenSSL_1_1_1c.tar.gz && \
-	cd openssl-OpenSSL_1_1_1c && \
-	PERL="$HOME/ffmpeg_build/bin/perl" ./config --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
-	make -j4 && \
-	make install_sw && \
-	cd ~/ffmpeg_sources && \
+	make install
+
+RUN cd ~/ffmpeg_sources && \
 	curl -O -L https://ffmpeg.org/releases/ffmpeg-snapshot.tar.bz2 && \
-	tar xjvf ffmpeg-snapshot.tar.bz2 && \
+	tar -xf ffmpeg-snapshot.tar.bz2 && \
 	cd ffmpeg && \
 	PATH=~/bin:$PATH && \
 	PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" ./configure --prefix="$HOME/ffmpeg_build" --extra-cflags="-I$HOME/ffmpeg_build/include" --extra-ldflags="-L$HOME/ffmpeg_build/lib" --enable-openssl --enable-libvpx --enable-shared --enable-pic --bindir="$HOME/bin" && \
@@ -78,30 +91,15 @@ RUN	yum remove nasm -y && \
 ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig:/root/ffmpeg_build/lib/pkgconfig
 ENV LDFLAGS -L/root/ffmpeg_build/lib
 
-RUN mkdir libjpeg-turbo && \
-	cd libjpeg-turbo && \
-	export PATH=~/bin:$PATH && \
-	curl -L https://kent.dl.sourceforge.net/project/libjpeg-turbo/1.5.3/libjpeg-turbo-1.5.3.tar.gz > libjpeg-turbo-1.5.3.tar.gz && \
-	tar xzvf libjpeg-turbo-1.5.3.tar.gz && \
-	cd libjpeg-turbo-1.5.3 && \
-	export CFLAGS="-fPIC" && \
-	export CXXFLAGS="-fPIC" && \
-	autoreconf -fiv && \
-	./configure --host=i686-pc-linux-gnu && \
-	make && \
-	make install && \
-	cd ../../ && \
-	rm -rf libjpeg-turbo
-
-ENV JPEG_LIBRARY /opt/libjpeg-turbo/lib32/libjpeg.a
-ENV JPEG_INCLUDE_DIR /opt/libjpeg-turbo/include
-
 RUN curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/uapi/linux/videodev2.h && \
 	curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/uapi/linux/v4l2-common.h && \
 	curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/uapi/linux/v4l2-controls.h && \
 	curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/linux/compiler.h && \
 	mv videodev2.h v4l2-common.h v4l2-controls.h compiler.h /usr/include/linux
 
+#in i686, yum metadata ends up with slightly wrong timestamps
+#which inhibits its update
+#https://github.com/skvark/opencv-python/issues/148
 RUN yum clean all
 
 ENV PATH "$HOME/bin:$PATH"

--- a/docker/Dockerfile_i686
+++ b/docker/Dockerfile_i686
@@ -45,11 +45,11 @@ RUN yum install autoconf automake bzip2 cmake freetype-devel gcc gcc-c++ libtool
 	./configure --prefix="$HOME/ffmpeg_build" --disable-examples --disable-unit-tests --enable-vp9-highbitdepth --as=yasm --enable-pic --enable-shared && \
 	make -j4 && \
 	make install && \
-        cd ~/ffmpeg_sources && \
+    cd ~/ffmpeg_sources && \
 	curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1c.tar.gz && \
 	tar -zxvf OpenSSL_1_1_1c.tar.gz && \
 	cd openssl-OpenSSL_1_1_1c && \
-	./configure --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
+	./Configure --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
 	make -j4 && \
 	make install && \
 	cd ~/ffmpeg_sources && \

--- a/docker/Dockerfile_i686
+++ b/docker/Dockerfile_i686
@@ -13,18 +13,28 @@ RUN curl -O -L https://download.qt.io/archive/qt/4.8/4.8.7/qt-everywhere-opensou
 ENV QTDIR /opt/Qt4.8.7
 ENV PATH "$QTDIR/bin:$PATH"
 
-RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz && \
-	tar -zxf cmake-3.9.0.tar.gz && \
-	cd cmake-3.9.0 && \
-	yum -y install curl-devel zlib-devel && \
-	./configure --system-curl && \
-	make && \
-	make install && \
-	cd .. && \
+RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz  && \
+	tar -zxf cmake-3.9.0.tar.gz  && \
+	cd cmake-3.9.0  && \
+	yum -y install curl-devel zlib-devel  && \
+	./configure --system-curl  && \
+	make -j4 && \
+	make install  && \
+	cd ..  && \
 	rm -rf cmake-3.9.0*
 
-RUN yum install autoconf automake bzip2 cmake freetype-devel gcc gcc-c++ libtool make mercurial pkgconfig perl-core zlib-devel -y && \
-	yum remove nasm -y && \
+RUN curl -O -L  https://www.cpan.org/src/5.0/perl-5.10.1.tar.gz  && \
+	tar -xzf perl-5.10.1.tar.gz && \
+	yum install autoconf automake bzip2 git freetype-devel gcc gcc-c++ libtool make pkgconfig  -y  && \
+	cd perl-5.10.1  && \
+	./Configure -des -Dprefix=$HOME/ffmpeg_build && \
+	make -j4 && \
+	make install && \
+	cd ..  && \
+	rm -rf perl-5.10.1* && \
+	PATH=$HOME/ffmpeg_build/bin:$PATH #otherwise perl not detected at runtime
+
+RUN	yum remove nasm -y && \
 	mkdir ~/ffmpeg_sources && \
 	cd ~/ffmpeg_sources && \
 	curl -O -L http://www.nasm.us/pub/nasm/releasebuilds/2.13.02/nasm-2.13.02.tar.bz2 && \
@@ -45,19 +55,19 @@ RUN yum install autoconf automake bzip2 cmake freetype-devel gcc gcc-c++ libtool
 	./configure --prefix="$HOME/ffmpeg_build" --disable-examples --disable-unit-tests --enable-vp9-highbitdepth --as=yasm --enable-pic --enable-shared && \
 	make -j4 && \
 	make install && \
-    cd ~/ffmpeg_sources && \
+	cd ~/ffmpeg_sources && \
 	curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1c.tar.gz && \
 	tar -zxvf OpenSSL_1_1_1c.tar.gz && \
 	cd openssl-OpenSSL_1_1_1c && \
-	./Configure --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
+	./config --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
 	make -j4 && \
-	make install && \
+	make install_sw && \ #skip building man-pages
 	cd ~/ffmpeg_sources && \
 	curl -O -L https://ffmpeg.org/releases/ffmpeg-snapshot.tar.bz2 && \
 	tar xjvf ffmpeg-snapshot.tar.bz2 && \
 	cd ffmpeg && \
 	PATH=~/bin:$PATH && \
-	PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" ./configure --prefix="$HOME/ffmpeg_build" --extra-cflags="-I$HOME/ffmpeg_build/include" --extra-ldflags="-L$HOME/ffmpeg_build/lib" --enable-libvpx --enable-openssl --enable-shared --enable-pic --bindir="$HOME/bin" && \
+	PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" ./configure --prefix="$HOME/ffmpeg_build" --extra-cflags="-I$HOME/ffmpeg_build/include" --extra-ldflags="-L$HOME/ffmpeg_build/lib" --enable-openssl --enable-libvpx --enable-shared --enable-pic --bindir="$HOME/bin" && \
 	make -j4 && \
 	make install && \
 	echo "/root/ffmpeg_build/lib/" >> /etc/ld.so.conf && \

--- a/docker/Dockerfile_i686
+++ b/docker/Dockerfile_i686
@@ -24,14 +24,14 @@ RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz && \
 	rm -rf cmake-3.9.0*
 
 RUN	yum install autoconf automake bzip2 git freetype-devel gcc gcc-c++ libtool make pkgconfig -y && \
-    curl -O -L https://www.cpan.org/src/5.0/perl-5.10.1.tar.gz && \
-	tar -xzf perl-5.10.1.tar.gz && \
-	cd perl-5.10.1 && \
+    curl -O -L https://www.cpan.org/src/5.0/perl-5.20.1.tar.gz && \
+	tar -xzf perl-5.20.1.tar.gz && \
+	cd perl-5.20.1 && \
 	./Configure -des -Dprefix="$HOME/ffmpeg_build" && \
 	make -j4 && \
 	make install && \
 	cd .. && \
-	rm -rf perl-5.10.1*
+	rm -rf perl-5.20.1*
 
 RUN	yum remove nasm -y && \
 	mkdir ~/ffmpeg_sources && \

--- a/docker/Dockerfile_i686
+++ b/docker/Dockerfile_i686
@@ -13,26 +13,25 @@ RUN curl -O -L https://download.qt.io/archive/qt/4.8/4.8.7/qt-everywhere-opensou
 ENV QTDIR /opt/Qt4.8.7
 ENV PATH "$QTDIR/bin:$PATH"
 
-RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz  && \
-	tar -zxf cmake-3.9.0.tar.gz  && \
-	cd cmake-3.9.0  && \
-	yum -y install curl-devel zlib-devel  && \
-	./configure --system-curl  && \
-	make -j4 && \
-	make install  && \
-	cd ..  && \
-	rm -rf cmake-3.9.0*
-
-RUN curl -O -L  https://www.cpan.org/src/5.0/perl-5.10.1.tar.gz  && \
-	tar -xzf perl-5.10.1.tar.gz && \
-	yum install autoconf automake bzip2 git freetype-devel gcc gcc-c++ libtool make pkgconfig  -y  && \
-	cd perl-5.10.1  && \
-	./Configure -des -Dprefix=$HOME/ffmpeg_build && \
+RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz && \
+	tar -zxf cmake-3.9.0.tar.gz && \
+	cd cmake-3.9.0 && \
+	yum -y install curl-devel zlib-devel && \
+	./configure --system-curl && \
 	make -j4 && \
 	make install && \
-	cd ..  && \
-	rm -rf perl-5.10.1* && \
-	PATH=$HOME/ffmpeg_build/bin:$PATH #otherwise perl not detected at runtime
+	cd .. && \
+	rm -rf cmake-3.9.0*
+
+RUN	yum install autoconf automake bzip2 git freetype-devel gcc gcc-c++ libtool make pkgconfig -y && \
+    curl -O -L https://www.cpan.org/src/5.0/perl-5.10.1.tar.gz && \
+	tar -xzf perl-5.10.1.tar.gz && \
+	cd perl-5.10.1 && \
+	./Configure -des -Dprefix="$HOME/ffmpeg_build" && \
+	make -j4 && \
+	make install && \
+	cd .. && \
+	rm -rf perl-5.10.1*
 
 RUN	yum remove nasm -y && \
 	mkdir ~/ffmpeg_sources && \
@@ -59,9 +58,9 @@ RUN	yum remove nasm -y && \
 	curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1c.tar.gz && \
 	tar -zxvf OpenSSL_1_1_1c.tar.gz && \
 	cd openssl-OpenSSL_1_1_1c && \
-	./config --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
+	PERL="$HOME/ffmpeg_build/bin/perl" ./config --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
 	make -j4 && \
-	make install_sw && \ #skip building man-pages
+	make install_sw && \
 	cd ~/ffmpeg_sources && \
 	curl -O -L https://ffmpeg.org/releases/ffmpeg-snapshot.tar.bz2 && \
 	tar xjvf ffmpeg-snapshot.tar.bz2 && \

--- a/docker/Dockerfile_i686
+++ b/docker/Dockerfile_i686
@@ -23,7 +23,7 @@ RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz && \
 	cd .. && \
 	rm -rf cmake-3.9.0*
 
-RUN yum install autoconf automake bzip2 cmake freetype-devel gcc gcc-c++ libtool make mercurial pkgconfig openssl-devel zlib-devel -y && \
+RUN yum install autoconf automake bzip2 cmake freetype-devel gcc gcc-c++ libtool make mercurial pkgconfig perl-core zlib-devel -y && \
 	yum remove nasm -y && \
 	mkdir ~/ffmpeg_sources && \
 	cd ~/ffmpeg_sources && \
@@ -45,12 +45,19 @@ RUN yum install autoconf automake bzip2 cmake freetype-devel gcc gcc-c++ libtool
 	./configure --prefix="$HOME/ffmpeg_build" --disable-examples --disable-unit-tests --enable-vp9-highbitdepth --as=yasm --enable-pic --enable-shared && \
 	make -j4 && \
 	make install && \
+        cd ~/ffmpeg_sources && \
+	curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1c.tar.gz && \
+	tar -zxvf OpenSSL_1_1_1c.tar.gz && \
+	cd openssl-OpenSSL_1_1_1c && \
+	./configure --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
+	make -j4 && \
+	make install && \
 	cd ~/ffmpeg_sources && \
 	curl -O -L https://ffmpeg.org/releases/ffmpeg-snapshot.tar.bz2 && \
 	tar xjvf ffmpeg-snapshot.tar.bz2 && \
 	cd ffmpeg && \
 	PATH=~/bin:$PATH && \
-	PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" ./configure --prefix="$HOME/ffmpeg_build" --extra-cflags="-I$HOME/ffmpeg_build/include" --extra-ldflags="-L$HOME/ffmpeg_build/lib" --enable-libvpx --enable-openssl --enable-protocol=file,ftp,http,https,httpproxy,hls,mmsh,mmst,pipe,rtmp,rtmps,rtmpt,rtmpts,rtp,sctp,srtp,tcp,udp --enable-shared --enable-pic --bindir="$HOME/bin" && \
+	PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" ./configure --prefix="$HOME/ffmpeg_build" --extra-cflags="-I$HOME/ffmpeg_build/include" --extra-ldflags="-L$HOME/ffmpeg_build/lib" --enable-libvpx --enable-openssl --enable-shared --enable-pic --bindir="$HOME/bin" && \
 	make -j4 && \
 	make install && \
 	echo "/root/ffmpeg_build/lib/" >> /etc/ld.so.conf && \

--- a/docker/Dockerfile_i686
+++ b/docker/Dockerfile_i686
@@ -23,7 +23,7 @@ RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz && \
 	cd .. && \
 	rm -rf cmake-3.9.0*
 
-RUN yum install autoconf automake bzip2 cmake freetype-devel gcc gcc-c++ libtool make mercurial pkgconfig zlib-devel -y && \
+RUN yum install autoconf automake bzip2 cmake freetype-devel gcc gcc-c++ libtool make mercurial pkgconfig openssl-devel zlib-devel -y && \
 	yum remove nasm -y && \
 	mkdir ~/ffmpeg_sources && \
 	cd ~/ffmpeg_sources && \
@@ -50,7 +50,7 @@ RUN yum install autoconf automake bzip2 cmake freetype-devel gcc gcc-c++ libtool
 	tar xjvf ffmpeg-snapshot.tar.bz2 && \
 	cd ffmpeg && \
 	PATH=~/bin:$PATH && \
-	PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" ./configure --prefix="$HOME/ffmpeg_build" --extra-cflags="-I$HOME/ffmpeg_build/include" --extra-ldflags="-L$HOME/ffmpeg_build/lib" --enable-libvpx --enable-shared --enable-pic --bindir="$HOME/bin" && \
+	PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" ./configure --prefix="$HOME/ffmpeg_build" --extra-cflags="-I$HOME/ffmpeg_build/include" --extra-ldflags="-L$HOME/ffmpeg_build/lib" --enable-libvpx --enable-openssl --enable-protocol=file,ftp,http,https,httpproxy,hls,mmsh,mmst,pipe,rtmp,rtmps,rtmpt,rtmpts,rtp,sctp,srtp,tcp,udp --enable-shared --enable-pic --bindir="$HOME/bin" && \
 	make -j4 && \
 	make install && \
 	echo "/root/ffmpeg_build/lib/" >> /etc/ld.so.conf && \

--- a/docker/Dockerfile_x86_64
+++ b/docker/Dockerfile_x86_64
@@ -14,56 +14,69 @@ ENV QTDIR /opt/Qt4.8.7
 ENV PATH "$QTDIR/bin:$PATH"
 
 RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz && \
-	tar -zxf cmake-3.9.0.tar.gz && \
+	tar -xf cmake-3.9.0.tar.gz && \
 	cd cmake-3.9.0 && \
-	yum -y install curl-devel zlib-devel && \
+    true '#manylinux1 provides curl-devel equivalent and libcurl statically linked \
+         against the same newer OpenSSL as other source-built tools \
+         (1.0.2s as of this writing)' && \
+	yum -y install zlib-devel && \
 	./configure --system-curl && \
 	make -j4 && \
 	make install && \
 	cd .. && \
 	rm -rf cmake-3.9.0*
 
-RUN	yum install autoconf automake bzip2 git freetype-devel gcc gcc-c++ libtool make pkgconfig -y && \
-    curl -O -L https://www.cpan.org/src/5.0/perl-5.20.1.tar.gz && \
-	tar -xzf perl-5.20.1.tar.gz && \
+# https://trac.ffmpeg.org/wiki/CompilationGuide/Centos#GettheDependencies
+# manylinux provides the toolchain and git; we provide cmake
+RUN yum install freetype-devel bzip2-devel zlib-devel -y && \
+    mkdir ~/ffmpeg_sources
+
+# Newer openssl configure requires newer perl
+RUN curl -O -L https://www.cpan.org/src/5.0/perl-5.20.1.tar.gz && \
+	tar -xf perl-5.20.1.tar.gz && \
 	cd perl-5.20.1 && \
-	./Configure -des -Dprefix="$HOME/ffmpeg_build" && \
-	make -j4 && \
-	make install && \
+	./Configure -des -Dprefix="$HOME/openssl_build" && \
+	true '#perl build scripts do much redundant work \
+	     if running "make install" separately' && \
+	make install -j4 && \
 	cd .. && \
 	rm -rf perl-5.20.1*
 
-RUN	yum remove nasm -y && \
-	mkdir ~/ffmpeg_sources && \
-	cd ~/ffmpeg_sources && \
+RUN cd ~/ffmpeg_sources && \
+	curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1c.tar.gz && \
+	tar -xf OpenSSL_1_1_1c.tar.gz && \
+	cd openssl-OpenSSL_1_1_1c && \
+	PERL="$HOME/openssl_build/bin/perl" ./config --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
+	make -j4 && \
+    true '#skip installing documentation' && \
+	make install_sw && \
+    rm -rf ~/openssl_build
+
+RUN cd ~/ffmpeg_sources && \
 	curl -O -L http://www.nasm.us/pub/nasm/releasebuilds/2.13.02/nasm-2.13.02.tar.bz2 && \
-	tar xjvf nasm-2.13.02.tar.bz2 && cd nasm-2.13.02 && ./autogen.sh && \
+	tar -xf nasm-2.13.02.tar.bz2 && cd nasm-2.13.02 && ./autogen.sh && \
 	./configure --prefix="$HOME/ffmpeg_build" --bindir="$HOME/bin" && \
 	make -j4 && \
-	make install && \
-	cd ~/ffmpeg_sources && \
+	make install
+
+RUN cd ~/ffmpeg_sources && \
 	curl -O -L http://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz && \
-	tar xzvf yasm-1.3.0.tar.gz && \
+	tar -xf yasm-1.3.0.tar.gz && \
 	cd yasm-1.3.0 && \
 	./configure --prefix="$HOME/ffmpeg_build" --bindir="$HOME/bin" && \
 	make -j4 && \
-	make install && \
-	cd ~/ffmpeg_sources && \
+	make install
+
+RUN cd ~/ffmpeg_sources && \
 	git clone --depth 1 https://chromium.googlesource.com/webm/libvpx.git && \
 	cd libvpx && \
 	./configure --prefix="$HOME/ffmpeg_build" --disable-examples --disable-unit-tests --enable-vp9-highbitdepth --as=yasm --enable-pic --enable-shared && \
 	make -j4 && \
-	make install && \
-	cd ~/ffmpeg_sources && \
-	curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1c.tar.gz && \
-	tar -zxvf OpenSSL_1_1_1c.tar.gz && \
-	cd openssl-OpenSSL_1_1_1c && \
-	PERL="$HOME/ffmpeg_build/bin/perl" ./config --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
-	make -j4 && \
-	make install_sw && \
-	cd ~/ffmpeg_sources && \
+	make install
+
+RUN cd ~/ffmpeg_sources && \
 	curl -O -L https://ffmpeg.org/releases/ffmpeg-snapshot.tar.bz2 && \
-	tar xjvf ffmpeg-snapshot.tar.bz2 && \
+	tar -xf ffmpeg-snapshot.tar.bz2 && \
 	cd ffmpeg && \
 	PATH=~/bin:$PATH && \
 	PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" ./configure --prefix="$HOME/ffmpeg_build" --extra-cflags="-I$HOME/ffmpeg_build/include" --extra-ldflags="-L$HOME/ffmpeg_build/lib" --enable-openssl --enable-libvpx --enable-shared --enable-pic --bindir="$HOME/bin" && \
@@ -75,24 +88,6 @@ RUN	yum remove nasm -y && \
 
 ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig:/root/ffmpeg_build/lib/pkgconfig
 ENV LDFLAGS -L/root/ffmpeg_build/lib
-
-RUN mkdir libjpeg-turbo && \
-	cd libjpeg-turbo && \
-	export PATH=~/bin:$PATH && \
-	curl -L https://kent.dl.sourceforge.net/project/libjpeg-turbo/1.5.3/libjpeg-turbo-1.5.3.tar.gz > libjpeg-turbo-1.5.3.tar.gz && \
-	tar xzvf libjpeg-turbo-1.5.3.tar.gz && \
-	cd libjpeg-turbo-1.5.3 && \
-	export CFLAGS="-fPIC" && \
-	export CXXFLAGS="-fPIC" && \
-	autoreconf -fiv && \
-	./configure && \
-	make && \
-	make install && \
-	cd ../../ && \
-	rm -rf libjpeg-turbo
-
-ENV JPEG_LIBRARY /opt/libjpeg-turbo/lib64/libjpeg.a
-ENV JPEG_INCLUDE_DIR /opt/libjpeg-turbo/include
 
 RUN curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/uapi/linux/videodev2.h && \
 	curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/uapi/linux/v4l2-common.h && \

--- a/docker/Dockerfile_x86_64
+++ b/docker/Dockerfile_x86_64
@@ -23,7 +23,7 @@ RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz && \
 	cd .. && \
 	rm -rf cmake-3.9.0*
 
-RUN yum install autoconf automake bzip2 cmake freetype-devel gcc gcc-c++ libtool make mercurial pkgconfig zlib-devel -y && \
+RUN yum install autoconf automake bzip2 cmake freetype-devel gcc gcc-c++ libtool make mercurial pkgconfig openssl-devel zlib-devel -y && \
 	yum remove nasm -y && \
 	mkdir ~/ffmpeg_sources && \
 	cd ~/ffmpeg_sources && \
@@ -50,7 +50,7 @@ RUN yum install autoconf automake bzip2 cmake freetype-devel gcc gcc-c++ libtool
 	tar xjvf ffmpeg-snapshot.tar.bz2 && \
 	cd ffmpeg && \
 	PATH=~/bin:$PATH && \
-	PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" ./configure --prefix="$HOME/ffmpeg_build" --extra-cflags="-I$HOME/ffmpeg_build/include" --extra-ldflags="-L$HOME/ffmpeg_build/lib" --enable-libvpx --enable-shared --enable-pic --bindir="$HOME/bin" && \
+	PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" ./configure --prefix="$HOME/ffmpeg_build" --extra-cflags="-I$HOME/ffmpeg_build/include" --extra-ldflags="-L$HOME/ffmpeg_build/lib" --enable-openssl --enable-libvpx --enable-protocol=file,ftp,http,https,httpproxy,hls,mmsh,mmst,pipe,rtmp,rtmps,rtmpt,rtmpts,rtp,sctp,srtp,tcp,udp --enable-shared --enable-pic --bindir="$HOME/bin" && \
 	make -j4 && \
 	make install && \
 	echo "/root/ffmpeg_build/lib/" >> /etc/ld.so.conf && \

--- a/docker/Dockerfile_x86_64
+++ b/docker/Dockerfile_x86_64
@@ -23,7 +23,7 @@ RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz && \
 	cd .. && \
 	rm -rf cmake-3.9.0*
 
-RUN yum install autoconf automake bzip2 cmake freetype-devel gcc gcc-c++ libtool make mercurial pkgconfig openssl-devel zlib-devel -y && \
+RUN yum install autoconf automake bzip2 cmake freetype-devel gcc gcc-c++ libtool make mercurial pkgconfig perl-core zlib-devel -y && \
 	yum remove nasm -y && \
 	mkdir ~/ffmpeg_sources && \
 	cd ~/ffmpeg_sources && \
@@ -46,11 +46,18 @@ RUN yum install autoconf automake bzip2 cmake freetype-devel gcc gcc-c++ libtool
 	make -j4 && \
 	make install && \
 	cd ~/ffmpeg_sources && \
+	curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1c.tar.gz && \
+	tar -zxvf OpenSSL_1_1_1c.tar.gz && \
+	cd openssl-OpenSSL_1_1_1c && \
+	./configure --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
+	make -j4 && \
+	make install && \
+	cd ~/ffmpeg_sources && \
 	curl -O -L https://ffmpeg.org/releases/ffmpeg-snapshot.tar.bz2 && \
 	tar xjvf ffmpeg-snapshot.tar.bz2 && \
 	cd ffmpeg && \
 	PATH=~/bin:$PATH && \
-	PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" ./configure --prefix="$HOME/ffmpeg_build" --extra-cflags="-I$HOME/ffmpeg_build/include" --extra-ldflags="-L$HOME/ffmpeg_build/lib" --enable-openssl --enable-libvpx --enable-protocol=file,ftp,http,https,httpproxy,hls,mmsh,mmst,pipe,rtmp,rtmps,rtmpt,rtmpts,rtp,sctp,srtp,tcp,udp --enable-shared --enable-pic --bindir="$HOME/bin" && \
+	PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" ./configure --prefix="$HOME/ffmpeg_build" --extra-cflags="-I$HOME/ffmpeg_build/include" --extra-ldflags="-L$HOME/ffmpeg_build/lib" --enable-openssl --enable-libvpx --enable-shared --enable-pic --bindir="$HOME/bin" && \
 	make -j4 && \
 	make install && \
 	echo "/root/ffmpeg_build/lib/" >> /etc/ld.so.conf && \

--- a/docker/Dockerfile_x86_64
+++ b/docker/Dockerfile_x86_64
@@ -24,14 +24,14 @@ RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz && \
 	rm -rf cmake-3.9.0*
 
 RUN	yum install autoconf automake bzip2 git freetype-devel gcc gcc-c++ libtool make pkgconfig -y && \
-    curl -O -L https://www.cpan.org/src/5.0/perl-5.10.1.tar.gz && \
-	tar -xzf perl-5.10.1.tar.gz && \
-	cd perl-5.10.1 && \
+    curl -O -L https://www.cpan.org/src/5.0/perl-5.20.1.tar.gz && \
+	tar -xzf perl-5.20.1.tar.gz && \
+	cd perl-5.20.1 && \
 	./Configure -des -Dprefix="$HOME/ffmpeg_build" && \
 	make -j4 && \
 	make install && \
 	cd .. && \
-	rm -rf perl-5.10.1*
+	rm -rf perl-5.20.1*
 
 RUN	yum remove nasm -y && \
 	mkdir ~/ffmpeg_sources && \

--- a/docker/Dockerfile_x86_64
+++ b/docker/Dockerfile_x86_64
@@ -13,18 +13,28 @@ RUN curl -O -L https://download.qt.io/archive/qt/4.8/4.8.7/qt-everywhere-opensou
 ENV QTDIR /opt/Qt4.8.7
 ENV PATH "$QTDIR/bin:$PATH"
 
-RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz && \
-	tar -zxf cmake-3.9.0.tar.gz && \
-	cd cmake-3.9.0 && \
-	yum -y install curl-devel zlib-devel && \
-	./configure --system-curl && \
-	make && \
-	make install && \
-	cd .. && \
+RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz  && \
+	tar -zxf cmake-3.9.0.tar.gz  && \
+	cd cmake-3.9.0  && \
+	yum -y install curl-devel zlib-devel  && \
+	./configure --system-curl  && \
+	make -j4 && \
+	make install  && \
+	cd ..  && \
 	rm -rf cmake-3.9.0*
 
-RUN yum install autoconf automake bzip2 cmake freetype-devel gcc gcc-c++ libtool make mercurial pkgconfig perl-core zlib-devel -y && \
-	yum remove nasm -y && \
+RUN curl -O -L  https://www.cpan.org/src/5.0/perl-5.10.1.tar.gz  && \
+	tar -xzf perl-5.10.1.tar.gz && \
+	yum install autoconf automake bzip2 git freetype-devel gcc gcc-c++ libtool make pkgconfig  -y  && \
+	cd perl-5.10.1  && \
+	./Configure -des -Dprefix=$HOME/ffmpeg_build && \
+	make -j4 && \
+	make install && \
+	cd ..  && \
+	rm -rf perl-5.10.1* && \
+	PATH=$HOME/ffmpeg_build/bin:$PATH
+
+RUN	yum remove nasm -y && \
 	mkdir ~/ffmpeg_sources && \
 	cd ~/ffmpeg_sources && \
 	curl -O -L http://www.nasm.us/pub/nasm/releasebuilds/2.13.02/nasm-2.13.02.tar.bz2 && \
@@ -49,9 +59,9 @@ RUN yum install autoconf automake bzip2 cmake freetype-devel gcc gcc-c++ libtool
 	curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1c.tar.gz && \
 	tar -zxvf OpenSSL_1_1_1c.tar.gz && \
 	cd openssl-OpenSSL_1_1_1c && \
-	./Configure --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
+	./config --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
 	make -j4 && \
-	make install && \
+	make install_sw && \
 	cd ~/ffmpeg_sources && \
 	curl -O -L https://ffmpeg.org/releases/ffmpeg-snapshot.tar.bz2 && \
 	tar xjvf ffmpeg-snapshot.tar.bz2 && \

--- a/docker/Dockerfile_x86_64
+++ b/docker/Dockerfile_x86_64
@@ -13,26 +13,25 @@ RUN curl -O -L https://download.qt.io/archive/qt/4.8/4.8.7/qt-everywhere-opensou
 ENV QTDIR /opt/Qt4.8.7
 ENV PATH "$QTDIR/bin:$PATH"
 
-RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz  && \
-	tar -zxf cmake-3.9.0.tar.gz  && \
-	cd cmake-3.9.0  && \
-	yum -y install curl-devel zlib-devel  && \
-	./configure --system-curl  && \
-	make -j4 && \
-	make install  && \
-	cd ..  && \
-	rm -rf cmake-3.9.0*
-
-RUN curl -O -L  https://www.cpan.org/src/5.0/perl-5.10.1.tar.gz  && \
-	tar -xzf perl-5.10.1.tar.gz && \
-	yum install autoconf automake bzip2 git freetype-devel gcc gcc-c++ libtool make pkgconfig  -y  && \
-	cd perl-5.10.1  && \
-	./Configure -des -Dprefix=$HOME/ffmpeg_build && \
+RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz && \
+	tar -zxf cmake-3.9.0.tar.gz && \
+	cd cmake-3.9.0 && \
+	yum -y install curl-devel zlib-devel && \
+	./configure --system-curl && \
 	make -j4 && \
 	make install && \
-	cd ..  && \
-	rm -rf perl-5.10.1* && \
-	PATH=$HOME/ffmpeg_build/bin:$PATH
+	cd .. && \
+	rm -rf cmake-3.9.0*
+
+RUN	yum install autoconf automake bzip2 git freetype-devel gcc gcc-c++ libtool make pkgconfig -y && \
+    curl -O -L https://www.cpan.org/src/5.0/perl-5.10.1.tar.gz && \
+	tar -xzf perl-5.10.1.tar.gz && \
+	cd perl-5.10.1 && \
+	./Configure -des -Dprefix="$HOME/ffmpeg_build" && \
+	make -j4 && \
+	make install && \
+	cd .. && \
+	rm -rf perl-5.10.1*
 
 RUN	yum remove nasm -y && \
 	mkdir ~/ffmpeg_sources && \
@@ -59,7 +58,7 @@ RUN	yum remove nasm -y && \
 	curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1c.tar.gz && \
 	tar -zxvf OpenSSL_1_1_1c.tar.gz && \
 	cd openssl-OpenSSL_1_1_1c && \
-	./config --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
+	PERL="$HOME/ffmpeg_build/bin/perl" ./config --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
 	make -j4 && \
 	make install_sw && \
 	cd ~/ffmpeg_sources && \

--- a/docker/Dockerfile_x86_64
+++ b/docker/Dockerfile_x86_64
@@ -49,7 +49,7 @@ RUN yum install autoconf automake bzip2 cmake freetype-devel gcc gcc-c++ libtool
 	curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1c.tar.gz && \
 	tar -zxvf OpenSSL_1_1_1c.tar.gz && \
 	cd openssl-OpenSSL_1_1_1c && \
-	./configure --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
+	./Configure --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
 	make -j4 && \
 	make install && \
 	cd ~/ffmpeg_sources && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,6 +10,5 @@ The images have following extra software installed:
 
 - Qt 4.8.7
 - Cmake 3.9.0
-- FFmpeg with libvpx (latest snapshots at the build time)
-- libjpeg-turbo 1.5.3
+- FFmpeg with libvpx (latest snapshots at the build time) and recent openssl
 - Some missing headers included from more recent Linux to be able to enable V4L / V4L2 support in OpenCV


### PR DESCRIPTION
## PR Description
This PR introduces Major Fixes and updates like OpenSSL for opencv-python's FFmpeg backend.

### Fixes
#204 
#193 

### Changes
- Major Fixes and updates for Docker files (both x86 & x86-64)
- Enabled FFmpeg backend with OpenSSL
- Removed `libjpeg-turbo` libs build from scratch
