### PR TITLE
Don't build unused Qt features; use all cores

### DIFF
--- a/docker/Dockerfile_i686
+++ b/docker/Dockerfile_i686
@@ -1,38 +1,38 @@
 FROM quay.io/pypa/manylinux1_i686:latest
 
 RUN curl -O -L https://download.qt.io/archive/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz && \
-	tar -xf qt-everywhere-opensource-src-4.8.7.tar.gz && \
-	cd qt-everywhere* && \
+    tar -xf qt-everywhere-opensource-src-4.8.7.tar.gz && \
+    cd qt-everywhere* && \
     #configure does a bootstrap make under the hood
     #manylinux1 is too old to have `nproc`
     export MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN) && \
     #OpenCV only links against QtCore, QtGui, QtTest
-	./configure -prefix /opt/Qt4.8.7 -release -opensource -confirm-license \
+    ./configure -prefix /opt/Qt4.8.7 -release -opensource -confirm-license \
     -no-sql-sqlite -no-qt3support -no-xmlpatterns -no-multimedia \
     -no-webkit -no-script -no-declarative -no-dbus -make libs && \
-	make && \
-	make install && \
-	cd .. && \
-	rm -rf qt-everywhere-opensource-src-4.8.7 && \
-	rm qt-everywhere-opensource-src-4.8.7.tar.gz
+    make && \
+    make install && \
+    cd .. && \
+    rm -rf qt-everywhere-opensource-src-4.8.7 && \
+    rm qt-everywhere-opensource-src-4.8.7.tar.gz
 
 ENV QTDIR /opt/Qt4.8.7
 ENV PATH "$QTDIR/bin:$PATH"
 
 RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz && \
-	tar -xf cmake-3.9.0.tar.gz && \
-	cd cmake-3.9.0 && \
+    tar -xf cmake-3.9.0.tar.gz && \
+    cd cmake-3.9.0 && \
     #manylinux1 provides curl-devel equivalent and libcurl statically linked
     # against the same newer OpenSSL as other source-built tools
     # (1.0.2s as of this writing)
-	yum -y install zlib-devel && \
-	#configure does a bootstrap make under the hood
+    yum -y install zlib-devel && \
+    #configure does a bootstrap make under the hood
     export MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN) && \
-	./configure --system-curl && \
-	make && \
-	make install && \
-	cd .. && \
-	rm -rf cmake-3.9.0*
+    ./configure --system-curl && \
+    make && \
+    make install && \
+    cd .. && \
+    rm -rf cmake-3.9.0*
 
 # https://trac.ffmpeg.org/wiki/CompilationGuide/Centos#GettheDependencies
 # manylinux provides the toolchain and git; we provide cmake
@@ -41,69 +41,69 @@ RUN yum install freetype-devel bzip2-devel zlib-devel -y && \
 
 # Newer openssl configure requires newer perl
 RUN curl -O -L https://www.cpan.org/src/5.0/perl-5.20.1.tar.gz && \
-	tar -xf perl-5.20.1.tar.gz && \
-	cd perl-5.20.1 && \
-	./Configure -des -Dprefix="$HOME/openssl_build" && \
-	#perl build scripts do much redundant work
-	# if running "make install" separately
-	make install -j$(getconf _NPROCESSORS_ONLN) && \
-	cd .. && \
-	rm -rf perl-5.20.1*
+    tar -xf perl-5.20.1.tar.gz && \
+    cd perl-5.20.1 && \
+    ./Configure -des -Dprefix="$HOME/openssl_build" && \
+    #perl build scripts do much redundant work
+    # if running "make install" separately
+    make install -j$(getconf _NPROCESSORS_ONLN) && \
+    cd .. && \
+    rm -rf perl-5.20.1*
 
 RUN cd ~/ffmpeg_sources && \
-	curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1c.tar.gz && \
-	tar -xf OpenSSL_1_1_1c.tar.gz && \
-	cd openssl-OpenSSL_1_1_1c && \
+    curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1c.tar.gz && \
+    tar -xf OpenSSL_1_1_1c.tar.gz && \
+    cd openssl-OpenSSL_1_1_1c && \
     #in i686, ./config detects x64 in i686 container without linux32
     # when run from "docker build"
-	PERL="$HOME/openssl_build/bin/perl" linux32 ./config --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
-	make -j$(getconf _NPROCESSORS_ONLN) && \
+    PERL="$HOME/openssl_build/bin/perl" linux32 ./config --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
+    make -j$(getconf _NPROCESSORS_ONLN) && \
     #skip installing documentation
-	make install_sw && \
+    make install_sw && \
     rm -rf ~/openssl_build
 
 RUN cd ~/ffmpeg_sources && \
-	curl -O -L http://www.nasm.us/pub/nasm/releasebuilds/2.13.02/nasm-2.13.02.tar.bz2 && \
-	tar -xf nasm-2.13.02.tar.bz2 && cd nasm-2.13.02 && ./autogen.sh && \
-	./configure --prefix="$HOME/ffmpeg_build" --bindir="$HOME/bin" && \
-	make -j$(getconf _NPROCESSORS_ONLN) && \
-	make install
+    curl -O -L http://www.nasm.us/pub/nasm/releasebuilds/2.13.02/nasm-2.13.02.tar.bz2 && \
+    tar -xf nasm-2.13.02.tar.bz2 && cd nasm-2.13.02 && ./autogen.sh && \
+    ./configure --prefix="$HOME/ffmpeg_build" --bindir="$HOME/bin" && \
+    make -j$(getconf _NPROCESSORS_ONLN) && \
+    make install
 
 RUN cd ~/ffmpeg_sources && \
-	curl -O -L http://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz && \
-	tar -xf yasm-1.3.0.tar.gz && \
-	cd yasm-1.3.0 && \
-	./configure --prefix="$HOME/ffmpeg_build" --bindir="$HOME/bin" && \
-	make -j$(getconf _NPROCESSORS_ONLN) && \
-	make install
+    curl -O -L http://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz && \
+    tar -xf yasm-1.3.0.tar.gz && \
+    cd yasm-1.3.0 && \
+    ./configure --prefix="$HOME/ffmpeg_build" --bindir="$HOME/bin" && \
+    make -j$(getconf _NPROCESSORS_ONLN) && \
+    make install
 
 RUN cd ~/ffmpeg_sources && \
-	git clone --depth 1 https://chromium.googlesource.com/webm/libvpx.git && \
-	cd libvpx && \
-	./configure --prefix="$HOME/ffmpeg_build" --disable-examples --disable-unit-tests --enable-vp9-highbitdepth --as=yasm --enable-pic --enable-shared && \
-	make -j$(getconf _NPROCESSORS_ONLN) && \
-	make install
+    git clone --depth 1 https://chromium.googlesource.com/webm/libvpx.git && \
+    cd libvpx && \
+    ./configure --prefix="$HOME/ffmpeg_build" --disable-examples --disable-unit-tests --enable-vp9-highbitdepth --as=yasm --enable-pic --enable-shared && \
+    make -j$(getconf _NPROCESSORS_ONLN) && \
+    make install
 
 RUN cd ~/ffmpeg_sources && \
-	curl -O -L https://ffmpeg.org/releases/ffmpeg-snapshot.tar.bz2 && \
-	tar -xf ffmpeg-snapshot.tar.bz2 && \
-	cd ffmpeg && \
-	PATH=~/bin:$PATH && \
-	PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" ./configure --prefix="$HOME/ffmpeg_build" --extra-cflags="-I$HOME/ffmpeg_build/include" --extra-ldflags="-L$HOME/ffmpeg_build/lib" --enable-openssl --enable-libvpx --enable-shared --enable-pic --bindir="$HOME/bin" && \
-	make -j$(getconf _NPROCESSORS_ONLN) && \
-	make install && \
-	echo "/root/ffmpeg_build/lib/" >> /etc/ld.so.conf && \
-	ldconfig && \
-	rm -rf ~/ffmpeg_sources
+    curl -O -L https://ffmpeg.org/releases/ffmpeg-snapshot.tar.bz2 && \
+    tar -xf ffmpeg-snapshot.tar.bz2 && \
+    cd ffmpeg && \
+    PATH=~/bin:$PATH && \
+    PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" ./configure --prefix="$HOME/ffmpeg_build" --extra-cflags="-I$HOME/ffmpeg_build/include" --extra-ldflags="-L$HOME/ffmpeg_build/lib" --enable-openssl --enable-libvpx --enable-shared --enable-pic --bindir="$HOME/bin" && \
+    make -j$(getconf _NPROCESSORS_ONLN) && \
+    make install && \
+    echo "/root/ffmpeg_build/lib/" >> /etc/ld.so.conf && \
+    ldconfig && \
+    rm -rf ~/ffmpeg_sources
 
 ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig:/root/ffmpeg_build/lib/pkgconfig
 ENV LDFLAGS -L/root/ffmpeg_build/lib
 
 RUN curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/uapi/linux/videodev2.h && \
-	curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/uapi/linux/v4l2-common.h && \
-	curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/uapi/linux/v4l2-controls.h && \
-	curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/linux/compiler.h && \
-	mv videodev2.h v4l2-common.h v4l2-controls.h compiler.h /usr/include/linux
+    curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/uapi/linux/v4l2-common.h && \
+    curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/uapi/linux/v4l2-controls.h && \
+    curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/linux/compiler.h && \
+    mv videodev2.h v4l2-common.h v4l2-controls.h compiler.h /usr/include/linux
 
 #in i686, yum metadata ends up with slightly wrong timestamps
 #which inhibits its update

--- a/docker/Dockerfile_i686
+++ b/docker/Dockerfile_i686
@@ -3,7 +3,10 @@ FROM quay.io/pypa/manylinux1_i686:latest
 RUN curl -O -L https://download.qt.io/archive/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz && \
 	tar -xf qt-everywhere-opensource-src-4.8.7.tar.gz && \
 	cd qt-everywhere* && \
+    true '#configure does a bootstrap make under the hood' && \
+    true '#manylinux1 is too old to have `nproc`' && \
     export MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN) && \
+    true '#opencv only links against QtCore, QtGui, QtTest' && \
 	./configure -prefix /opt/Qt4.8.7 -release -opensource -confirm-license \
     -no-sql-sqlite -no-qt3support -no-xmlpatterns -no-multimedia \
     -no-webkit -no-script -no-declarative -no-dbus -make libs && \
@@ -23,8 +26,10 @@ RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz && \
          against the same newer OpenSSL as other source-built tools \
          (1.0.2s as of this writing)' && \
 	yum -y install zlib-devel && \
+	true '#configure does a bootstrap make under the hood' && \
+    export MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN) && \
 	./configure --system-curl && \
-	make -j$(getconf _NPROCESSORS_ONLN) && \
+	make && \
 	make install && \
 	cd .. && \
 	rm -rf cmake-3.9.0*

--- a/docker/Dockerfile_i686
+++ b/docker/Dockerfile_i686
@@ -3,8 +3,11 @@ FROM quay.io/pypa/manylinux1_i686:latest
 RUN curl -O -L https://download.qt.io/archive/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz && \
 	tar -xf qt-everywhere-opensource-src-4.8.7.tar.gz && \
 	cd qt-everywhere* && \
-	./configure -prefix /opt/Qt4.8.7 -release -opensource -confirm-license && \
-	gmake -j5 && \
+    export MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN) && \
+	./configure -prefix /opt/Qt4.8.7 -release -opensource -confirm-license \
+    -no-sql-sqlite -no-qt3support -no-xmlpatterns -no-multimedia \
+    -no-webkit -no-script -no-declarative -no-dbus -make libs && \
+	gmake && \
 	gmake install && \
 	cd .. && \
 	rm -rf qt-everywhere-opensource-src-4.8.7 && \
@@ -16,6 +19,7 @@ ENV PATH "$QTDIR/bin:$PATH"
 RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz && \
 	tar -zxf cmake-3.9.0.tar.gz && \
 	cd cmake-3.9.0 && \
+    export MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN) && \
 	yum -y install curl-devel zlib-devel && \
 	./configure --system-curl && \
 	make && \
@@ -27,10 +31,11 @@ RUN yum install autoconf automake bzip2 cmake freetype-devel gcc gcc-c++ libtool
 	yum remove nasm -y && \
 	mkdir ~/ffmpeg_sources && \
 	cd ~/ffmpeg_sources && \
+    export MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN) && \
 	curl -O -L http://www.nasm.us/pub/nasm/releasebuilds/2.13.02/nasm-2.13.02.tar.bz2 && \
 	tar xjvf nasm-2.13.02.tar.bz2 && cd nasm-2.13.02 && ./autogen.sh && \
 	./configure --prefix="$HOME/ffmpeg_build" --bindir="$HOME/bin" && \
-	make -j4 && \
+	make && \
 	make install && \
 	cd ~/ffmpeg_sources && \
 	curl -O -L http://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz && \

--- a/docker/Dockerfile_i686
+++ b/docker/Dockerfile_i686
@@ -3,10 +3,10 @@ FROM quay.io/pypa/manylinux1_i686:latest
 RUN curl -O -L https://download.qt.io/archive/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz && \
 	tar -xf qt-everywhere-opensource-src-4.8.7.tar.gz && \
 	cd qt-everywhere* && \
-    true '#configure does a bootstrap make under the hood' && \
-    true '#manylinux1 is too old to have `nproc`' && \
+    #configure does a bootstrap make under the hood
+    #manylinux1 is too old to have `nproc`
     export MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN) && \
-    true '#opencv only links against QtCore, QtGui, QtTest' && \
+    #OpenCV only links against QtCore, QtGui, QtTest
 	./configure -prefix /opt/Qt4.8.7 -release -opensource -confirm-license \
     -no-sql-sqlite -no-qt3support -no-xmlpatterns -no-multimedia \
     -no-webkit -no-script -no-declarative -no-dbus -make libs && \
@@ -22,11 +22,11 @@ ENV PATH "$QTDIR/bin:$PATH"
 RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz && \
 	tar -xf cmake-3.9.0.tar.gz && \
 	cd cmake-3.9.0 && \
-    true '#manylinux1 provides curl-devel equivalent and libcurl statically linked \
-         against the same newer OpenSSL as other source-built tools \
-         (1.0.2s as of this writing)' && \
+    #manylinux1 provides curl-devel equivalent and libcurl statically linked
+    # against the same newer OpenSSL as other source-built tools
+    # (1.0.2s as of this writing)
 	yum -y install zlib-devel && \
-	true '#configure does a bootstrap make under the hood' && \
+	#configure does a bootstrap make under the hood
     export MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN) && \
 	./configure --system-curl && \
 	make && \
@@ -44,8 +44,8 @@ RUN curl -O -L https://www.cpan.org/src/5.0/perl-5.20.1.tar.gz && \
 	tar -xf perl-5.20.1.tar.gz && \
 	cd perl-5.20.1 && \
 	./Configure -des -Dprefix="$HOME/openssl_build" && \
-	true '#perl build scripts do much redundant work \
-	     if running "make install" separately' && \
+	#perl build scripts do much redundant work
+	# if running "make install" separately
 	make install -j$(getconf _NPROCESSORS_ONLN) && \
 	cd .. && \
 	rm -rf perl-5.20.1*
@@ -54,11 +54,11 @@ RUN cd ~/ffmpeg_sources && \
 	curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1c.tar.gz && \
 	tar -xf OpenSSL_1_1_1c.tar.gz && \
 	cd openssl-OpenSSL_1_1_1c && \
-    true '#in i686, ./config detects x64 in i686 without linux32 \
-         when run from "docker build"' && \
+    #in i686, ./config detects x64 in i686 container without linux32
+    # when run from "docker build"
 	PERL="$HOME/openssl_build/bin/perl" linux32 ./config --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
 	make -j$(getconf _NPROCESSORS_ONLN) && \
-    true '#skip installing documentation' && \
+    #skip installing documentation
 	make install_sw && \
     rm -rf ~/openssl_build
 

--- a/docker/Dockerfile_x86_64
+++ b/docker/Dockerfile_x86_64
@@ -3,8 +3,11 @@ FROM quay.io/pypa/manylinux1_x86_64:latest
 RUN curl -O -L https://download.qt.io/archive/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz && \
 	tar -xf qt-everywhere-opensource-src-4.8.7.tar.gz && \
 	cd qt-everywhere* && \
-	./configure -prefix /opt/Qt4.8.7 -release -opensource -confirm-license && \
-	gmake -j5 && \
+    export MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN) && \
+	./configure -prefix /opt/Qt4.8.7 -release -opensource -confirm-license \
+    -no-sql-sqlite -no-qt3support -no-xmlpatterns -no-multimedia \
+    -no-webkit -no-script -no-declarative -no-dbus -make libs && \
+	gmake && \
 	gmake install && \
 	cd .. && \
 	rm -rf qt-everywhere-opensource-src-4.8.7 && \
@@ -16,6 +19,7 @@ ENV PATH "$QTDIR/bin:$PATH"
 RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz && \
 	tar -zxf cmake-3.9.0.tar.gz && \
 	cd cmake-3.9.0 && \
+    export MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN) && \
 	yum -y install curl-devel zlib-devel && \
 	./configure --system-curl && \
 	make && \
@@ -27,10 +31,11 @@ RUN yum install autoconf automake bzip2 cmake freetype-devel gcc gcc-c++ libtool
 	yum remove nasm -y && \
 	mkdir ~/ffmpeg_sources && \
 	cd ~/ffmpeg_sources && \
+    export MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN) && \
 	curl -O -L http://www.nasm.us/pub/nasm/releasebuilds/2.13.02/nasm-2.13.02.tar.bz2 && \
 	tar xjvf nasm-2.13.02.tar.bz2 && cd nasm-2.13.02 && ./autogen.sh && \
 	./configure --prefix="$HOME/ffmpeg_build" --bindir="$HOME/bin" && \
-	make -j4 && \
+	make && \
 	make install && \
 	cd ~/ffmpeg_sources && \
 	curl -O -L http://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz && \

--- a/docker/Dockerfile_x86_64
+++ b/docker/Dockerfile_x86_64
@@ -3,10 +3,10 @@ FROM quay.io/pypa/manylinux1_x86_64:latest
 RUN curl -O -L https://download.qt.io/archive/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz && \
 	tar -xf qt-everywhere-opensource-src-4.8.7.tar.gz && \
 	cd qt-everywhere* && \
-    true '#configure does a bootstrap make under the hood' && \
-    true '#manylinux1 is too old to have `nproc`' && \
+    #configure does a bootstrap make under the hood
+    #manylinux1 is too old to have `nproc`
     export MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN) && \
-    true '#opencv only links against QtCore, QtGui, QtTest' && \
+    #OpenCV only links against QtCore, QtGui, QtTest
 	./configure -prefix /opt/Qt4.8.7 -release -opensource -confirm-license \
     -no-sql-sqlite -no-qt3support -no-xmlpatterns -no-multimedia \
     -no-webkit -no-script -no-declarative -no-dbus -make libs && \
@@ -22,11 +22,11 @@ ENV PATH "$QTDIR/bin:$PATH"
 RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz && \
 	tar -xf cmake-3.9.0.tar.gz && \
 	cd cmake-3.9.0 && \
-    true '#manylinux1 provides curl-devel equivalent and libcurl statically linked \
-         against the same newer OpenSSL as other source-built tools \
-         (1.0.2s as of this writing)' && \
+    #manylinux1 provides curl-devel equivalent and libcurl statically linked
+    # against the same newer OpenSSL as other source-built tools
+    # (1.0.2s as of this writing)
 	yum -y install zlib-devel && \
-	true '#configure does a bootstrap make under the hood' && \
+	#configure does a bootstrap make under the hood
     export MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN) && \
 	./configure --system-curl && \
 	make && \
@@ -44,8 +44,8 @@ RUN curl -O -L https://www.cpan.org/src/5.0/perl-5.20.1.tar.gz && \
 	tar -xf perl-5.20.1.tar.gz && \
 	cd perl-5.20.1 && \
 	./Configure -des -Dprefix="$HOME/openssl_build" && \
-	true '#perl build scripts do much redundant work \
-	     if running "make install" separately' && \
+	#perl build scripts do much redundant work
+	# if running "make install" separately
 	make install -j$(getconf _NPROCESSORS_ONLN) && \
 	cd .. && \
 	rm -rf perl-5.20.1*
@@ -56,7 +56,7 @@ RUN cd ~/ffmpeg_sources && \
 	cd openssl-OpenSSL_1_1_1c && \
 	PERL="$HOME/openssl_build/bin/perl" ./config --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
 	make -j$(getconf _NPROCESSORS_ONLN) && \
-    true '#skip installing documentation' && \
+    #skip installing documentation
 	make install_sw && \
     rm -rf ~/openssl_build
 

--- a/docker/Dockerfile_x86_64
+++ b/docker/Dockerfile_x86_64
@@ -3,12 +3,15 @@ FROM quay.io/pypa/manylinux1_x86_64:latest
 RUN curl -O -L https://download.qt.io/archive/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz && \
 	tar -xf qt-everywhere-opensource-src-4.8.7.tar.gz && \
 	cd qt-everywhere* && \
+    true '#configure does a bootstrap make under the hood' && \
+    true '#manylinux1 is too old to have `nproc`' && \
     export MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN) && \
+    true '#opencv only links against QtCore, QtGui, QtTest' && \
 	./configure -prefix /opt/Qt4.8.7 -release -opensource -confirm-license \
     -no-sql-sqlite -no-qt3support -no-xmlpatterns -no-multimedia \
     -no-webkit -no-script -no-declarative -no-dbus -make libs && \
-	gmake && \
-	gmake install && \
+	make && \
+	make install && \
 	cd .. && \
 	rm -rf qt-everywhere-opensource-src-4.8.7 && \
 	rm qt-everywhere-opensource-src-4.8.7.tar.gz
@@ -23,8 +26,10 @@ RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz && \
          against the same newer OpenSSL as other source-built tools \
          (1.0.2s as of this writing)' && \
 	yum -y install zlib-devel && \
+	true '#configure does a bootstrap make under the hood' && \
+    export MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN) && \
 	./configure --system-curl && \
-	make -j$(getconf _NPROCESSORS_ONLN) && \
+	make && \
 	make install && \
 	cd .. && \
 	rm -rf cmake-3.9.0*

--- a/docker/Dockerfile_x86_64
+++ b/docker/Dockerfile_x86_64
@@ -1,38 +1,38 @@
 FROM quay.io/pypa/manylinux1_x86_64:latest
 
 RUN curl -O -L https://download.qt.io/archive/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz && \
-	tar -xf qt-everywhere-opensource-src-4.8.7.tar.gz && \
-	cd qt-everywhere* && \
+    tar -xf qt-everywhere-opensource-src-4.8.7.tar.gz && \
+    cd qt-everywhere* && \
     #configure does a bootstrap make under the hood
     #manylinux1 is too old to have `nproc`
     export MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN) && \
     #OpenCV only links against QtCore, QtGui, QtTest
-	./configure -prefix /opt/Qt4.8.7 -release -opensource -confirm-license \
+    ./configure -prefix /opt/Qt4.8.7 -release -opensource -confirm-license \
     -no-sql-sqlite -no-qt3support -no-xmlpatterns -no-multimedia \
     -no-webkit -no-script -no-declarative -no-dbus -make libs && \
-	make && \
-	make install && \
-	cd .. && \
-	rm -rf qt-everywhere-opensource-src-4.8.7 && \
-	rm qt-everywhere-opensource-src-4.8.7.tar.gz
+    make && \
+    make install && \
+    cd .. && \
+    rm -rf qt-everywhere-opensource-src-4.8.7 && \
+    rm qt-everywhere-opensource-src-4.8.7.tar.gz
 
 ENV QTDIR /opt/Qt4.8.7
 ENV PATH "$QTDIR/bin:$PATH"
 
 RUN curl -O -L https://cmake.org/files/v3.9/cmake-3.9.0.tar.gz && \
-	tar -xf cmake-3.9.0.tar.gz && \
-	cd cmake-3.9.0 && \
+    tar -xf cmake-3.9.0.tar.gz && \
+    cd cmake-3.9.0 && \
     #manylinux1 provides curl-devel equivalent and libcurl statically linked
     # against the same newer OpenSSL as other source-built tools
     # (1.0.2s as of this writing)
-	yum -y install zlib-devel && \
-	#configure does a bootstrap make under the hood
+    yum -y install zlib-devel && \
+    #configure does a bootstrap make under the hood
     export MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN) && \
-	./configure --system-curl && \
-	make && \
-	make install && \
-	cd .. && \
-	rm -rf cmake-3.9.0*
+    ./configure --system-curl && \
+    make && \
+    make install && \
+    cd .. && \
+    rm -rf cmake-3.9.0*
 
 # https://trac.ffmpeg.org/wiki/CompilationGuide/Centos#GettheDependencies
 # manylinux provides the toolchain and git; we provide cmake
@@ -41,66 +41,66 @@ RUN yum install freetype-devel bzip2-devel zlib-devel -y && \
 
 # Newer openssl configure requires newer perl
 RUN curl -O -L https://www.cpan.org/src/5.0/perl-5.20.1.tar.gz && \
-	tar -xf perl-5.20.1.tar.gz && \
-	cd perl-5.20.1 && \
-	./Configure -des -Dprefix="$HOME/openssl_build" && \
-	#perl build scripts do much redundant work
-	# if running "make install" separately
-	make install -j$(getconf _NPROCESSORS_ONLN) && \
-	cd .. && \
-	rm -rf perl-5.20.1*
+    tar -xf perl-5.20.1.tar.gz && \
+    cd perl-5.20.1 && \
+    ./Configure -des -Dprefix="$HOME/openssl_build" && \
+    #perl build scripts do much redundant work
+    # if running "make install" separately
+    make install -j$(getconf _NPROCESSORS_ONLN) && \
+    cd .. && \
+    rm -rf perl-5.20.1*
 
 RUN cd ~/ffmpeg_sources && \
-	curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1c.tar.gz && \
-	tar -xf OpenSSL_1_1_1c.tar.gz && \
-	cd openssl-OpenSSL_1_1_1c && \
-	PERL="$HOME/openssl_build/bin/perl" ./config --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
-	make -j$(getconf _NPROCESSORS_ONLN) && \
+    curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_1_1c.tar.gz && \
+    tar -xf OpenSSL_1_1_1c.tar.gz && \
+    cd openssl-OpenSSL_1_1_1c && \
+    PERL="$HOME/openssl_build/bin/perl" ./config --prefix="$HOME/ffmpeg_build" --openssldir="$HOME/ffmpeg_build" shared zlib && \
+    make -j$(getconf _NPROCESSORS_ONLN) && \
     #skip installing documentation
-	make install_sw && \
+    make install_sw && \
     rm -rf ~/openssl_build
 
 RUN cd ~/ffmpeg_sources && \
-	curl -O -L http://www.nasm.us/pub/nasm/releasebuilds/2.13.02/nasm-2.13.02.tar.bz2 && \
-	tar -xf nasm-2.13.02.tar.bz2 && cd nasm-2.13.02 && ./autogen.sh && \
-	./configure --prefix="$HOME/ffmpeg_build" --bindir="$HOME/bin" && \
-	make -j$(getconf _NPROCESSORS_ONLN) && \
-	make install
+    curl -O -L http://www.nasm.us/pub/nasm/releasebuilds/2.13.02/nasm-2.13.02.tar.bz2 && \
+    tar -xf nasm-2.13.02.tar.bz2 && cd nasm-2.13.02 && ./autogen.sh && \
+    ./configure --prefix="$HOME/ffmpeg_build" --bindir="$HOME/bin" && \
+    make -j$(getconf _NPROCESSORS_ONLN) && \
+    make install
 
 RUN cd ~/ffmpeg_sources && \
-	curl -O -L http://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz && \
-	tar -xf yasm-1.3.0.tar.gz && \
-	cd yasm-1.3.0 && \
-	./configure --prefix="$HOME/ffmpeg_build" --bindir="$HOME/bin" && \
-	make -j$(getconf _NPROCESSORS_ONLN) && \
-	make install
+    curl -O -L http://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz && \
+    tar -xf yasm-1.3.0.tar.gz && \
+    cd yasm-1.3.0 && \
+    ./configure --prefix="$HOME/ffmpeg_build" --bindir="$HOME/bin" && \
+    make -j$(getconf _NPROCESSORS_ONLN) && \
+    make install
 
 RUN cd ~/ffmpeg_sources && \
-	git clone --depth 1 https://chromium.googlesource.com/webm/libvpx.git && \
-	cd libvpx && \
-	./configure --prefix="$HOME/ffmpeg_build" --disable-examples --disable-unit-tests --enable-vp9-highbitdepth --as=yasm --enable-pic --enable-shared && \
-	make -j$(getconf _NPROCESSORS_ONLN) && \
-	make install
+    git clone --depth 1 https://chromium.googlesource.com/webm/libvpx.git && \
+    cd libvpx && \
+    ./configure --prefix="$HOME/ffmpeg_build" --disable-examples --disable-unit-tests --enable-vp9-highbitdepth --as=yasm --enable-pic --enable-shared && \
+    make -j$(getconf _NPROCESSORS_ONLN) && \
+    make install
 
 RUN cd ~/ffmpeg_sources && \
-	curl -O -L https://ffmpeg.org/releases/ffmpeg-snapshot.tar.bz2 && \
-	tar -xf ffmpeg-snapshot.tar.bz2 && \
-	cd ffmpeg && \
-	PATH=~/bin:$PATH && \
-	PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" ./configure --prefix="$HOME/ffmpeg_build" --extra-cflags="-I$HOME/ffmpeg_build/include" --extra-ldflags="-L$HOME/ffmpeg_build/lib" --enable-openssl --enable-libvpx --enable-shared --enable-pic --bindir="$HOME/bin" && \
-	make -j$(getconf _NPROCESSORS_ONLN) && \
-	make install && \
-	echo "/root/ffmpeg_build/lib/" >> /etc/ld.so.conf && \
-	ldconfig && \
-	rm -rf ~/ffmpeg_sources
+    curl -O -L https://ffmpeg.org/releases/ffmpeg-snapshot.tar.bz2 && \
+    tar -xf ffmpeg-snapshot.tar.bz2 && \
+    cd ffmpeg && \
+    PATH=~/bin:$PATH && \
+    PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" ./configure --prefix="$HOME/ffmpeg_build" --extra-cflags="-I$HOME/ffmpeg_build/include" --extra-ldflags="-L$HOME/ffmpeg_build/lib" --enable-openssl --enable-libvpx --enable-shared --enable-pic --bindir="$HOME/bin" && \
+    make -j$(getconf _NPROCESSORS_ONLN) && \
+    make install && \
+    echo "/root/ffmpeg_build/lib/" >> /etc/ld.so.conf && \
+    ldconfig && \
+    rm -rf ~/ffmpeg_sources
 
 ENV PKG_CONFIG_PATH /usr/local/lib/pkgconfig:/root/ffmpeg_build/lib/pkgconfig
 ENV LDFLAGS -L/root/ffmpeg_build/lib
 
 RUN curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/uapi/linux/videodev2.h && \
-	curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/uapi/linux/v4l2-common.h && \
-	curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/uapi/linux/v4l2-controls.h && \
-	curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/linux/compiler.h && \
-	mv videodev2.h v4l2-common.h v4l2-controls.h compiler.h /usr/include/linux
+    curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/uapi/linux/v4l2-common.h && \
+    curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/uapi/linux/v4l2-controls.h && \
+    curl -O https://raw.githubusercontent.com/torvalds/linux/v4.14/include/linux/compiler.h && \
+    mv videodev2.h v4l2-common.h v4l2-controls.h compiler.h /usr/include/linux
 
 ENV PATH "$HOME/bin:$PATH"


### PR DESCRIPTION
This drastically reduces Qt compilation time and reduces the resulting image size by about 440M.

The resulting libs included into the wheel are reduced by about 600k.

I've checked that none of the excluded features are used:

* OpenCV only directly links to QtCore, QtGUI and QtTest -- and consequently, these are the only ones included into the manylinux1 wheel by auditwheel.
* Likewise, I checked that all the imports from those used by OpenCV are present in the reduced version.
* There's an issue for me with no icons in Qt `imshow()` UI. But it's also present in the vanilla wheel.
* Also considered `-no-nis` and `-no-cups` but ultimately decided against them: I'm not sure that the UI has no printing capabilities. (NIS support is used solely to discover network printers.)
* Likewise, didn't touch stuff like X features support: there's no such easy way to make sure they are not used.

Merge conflicts with https://github.com/skvark/opencv-python/pull/229 are all but guaranteed.