### PR TITLE
Fix for #266 - don't use deprecated brew tap-pin, instead refer to the full package name when installing

### DIFF
--- a/travis_config.sh
+++ b/travis_config.sh
@@ -98,11 +98,10 @@ function pre_build {
 
     echo 'Installing QT4'
     brew tap | grep -qxF cartr/qt4 || brew tap cartr/qt4
-    brew tap --list-pinned | grep -qxF cartr/qt4 || brew tap-pin cartr/qt4
     if [ -n "$CACHE_STAGE" ]; then
-        brew_install_and_cache_within_time_limit qt@4 || { [ $? -gt 1 ] && return 2 || return 0; }
+        brew_install_and_cache_within_time_limit cartr/qt4/qt@4 || { [ $? -gt 1 ] && return 2 || return 0; }
     else
-        brew install qt@4
+        brew install cartr/qt4/qt@4
     fi
 
     echo 'Installing FFmpeg'


### PR DESCRIPTION
don't use deprecated brew tap-pin
instead refer to the full package name when installing

fixes https://github.com/skvark/opencv-python/issues/266

context:
https://brew.sh/2019/04/04/homebrew-2.1.0/
https://github.com/Homebrew/brew/pull/5925