### PR TITLE
replace get_config_var()  with get_config_vars() in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ def main():
 
     package_data = {
         'cv2':
-            ['*%s' % sysconfig.get_config_var('SO')] +
+            ['*%s' % sysconfig.get_config_vars().get('SO')] +
             (['*.dll'] if os.name == 'nt' else []) +
             ["LICENSE.txt", "LICENSE-3RD-PARTY.txt"],
         'cv2.data':


### PR DESCRIPTION
The get_config_var() is deprecated since Python3, and it causes a warning: `warnings.warn('SO is deprecated, use EXT_SUFFIX', DeprecationWarning, 2)`

If we change to `get_config_vars().get("SO")`, it would be compatible with both Python2 and Python3. So why not  :-)