### PR TITLE
Fixes for python3 executables not detecting correctly in cmake

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,9 +123,8 @@ def main():
         "-DBUILD_TESTS=OFF",
         "-DBUILD_PERF_TESTS=OFF",
         "-DBUILD_DOCS=OFF"
-    ] +
-    # patch for OS-specific python libs
-    (["-DPYTHON3_LIBRARY=%s" % os.path.join(*[sysconfig.get_config_var('BINDIR'), "libs","python{}.lib".format("".join(str(v) for v in sys.version_info[:2]))])] if sys.platform.startswith('win') else ["-DPYTHON3_LIBRARY=%s" % os.path.join('/usr/lib/x86_64-linux-gnu/', sysconfig.get_config_var('LDLIBRARY'))]) +
+    ] + \
+    (["-DPYTHON3_LIBRARY=%s" % os.path.join(*[sysconfig.get_config_var('BINDIR'), "libs","python{}.lib".format("".join(str(v) for v in sys.version_info[:2]))])] if sys.platform.startswith('win') else ["-DPYTHON3_LIBRARY=%s" % os.path.join('/usr/lib/x86_64-linux-gnu/', sysconfig.get_config_var('LDLIBRARY'))]) + \
     (["-DOPENCV_EXTRA_MODULES_PATH=" + os.path.abspath("opencv_contrib/modules")] if build_contrib else [])
 
     # OS-specific components

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,6 @@ def main():
     ]) + [
         # skbuild inserts PYTHON_* vars. That doesn't satisfy opencv build scripts in case of Py3
         "-DPYTHON_DEFAULT_EXECUTABLE=%s" % sys.executable,
-        "-DPYTHON3_LIBRARY=%s" % os.path.join('/usr/lib/x86_64-linux-gnu/', sysconfig.get_config_var('LDLIBRARY')),
         "-DPYTHON3_INCLUDE_DIR=%s" % gp()['include'],
         "-DBUILD_opencv_python3=ON",
         "-DBUILD_opencv_python2=OFF",
@@ -124,7 +123,10 @@ def main():
         "-DBUILD_TESTS=OFF",
         "-DBUILD_PERF_TESTS=OFF",
         "-DBUILD_DOCS=OFF"
-    ] + (["-DOPENCV_EXTRA_MODULES_PATH=" + os.path.abspath("opencv_contrib/modules")] if build_contrib else [])
+    ] +
+    # patch for OS-specific python libs
+    (["-DPYTHON3_LIBRARY=%s" % os.path.join(*[sysconfig.get_config_var('BINDIR'), "libs","python{}.lib".format("".join(str(v) for v in sys.version_info[:2]))])] if sys.platform.startswith('win') else ["-DPYTHON3_LIBRARY=%s" % os.path.join('/usr/lib/x86_64-linux-gnu/', sysconfig.get_config_var('LDLIBRARY'))]) +
+    (["-DOPENCV_EXTRA_MODULES_PATH=" + os.path.abspath("opencv_contrib/modules")] if build_contrib else [])
 
     # OS-specific components
     if sys.platform.startswith('linux') and not build_headless:

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ import runpy
 import subprocess
 import re
 import sysconfig
+from sysconfig import get_paths as gp
 
 
 def main():
@@ -103,7 +104,8 @@ def main():
     ]) + [
         # skbuild inserts PYTHON_* vars. That doesn't satisfy opencv build scripts in case of Py3
         "-DPYTHON_DEFAULT_EXECUTABLE=%s" % sys.executable,
-        "-DPYTHON3_EXECUTABLE=%s" % sys.executable,
+        "-DPYTHON3_LIBRARY=%s" % os.path.join('/usr/lib/x86_64-linux-gnu/', sysconfig.get_config_var('LDLIBRARY')),
+        "-DPYTHON3_INCLUDE_DIR=%s" % gp()['include'],
         "-DBUILD_opencv_python3=ON",
         "-DBUILD_opencv_python2=OFF",
 


### PR DESCRIPTION
@skvark this patch will fix the issue where Python3 executables are not detecting correctly by cmake in `setup.py`. Goodluck :+1: 