### PR TITLE
Disable Java wrapper build by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The build can be customized with environment variables. In addition to any varia
 
 - ``CI_BUILD``. Set to ``1`` to emulate the CI environment build behaviour. Used only in CI builds to force certain build flags on in ``setup.py``. Do not use this unless you know what you are doing.
 - ``ENABLE_CONTRIB`` and ``ENABLE_HEADLESS``. Set to ``1`` to build the contrib and/or headless version
+- ``ENABLE_JAVA``, Set to ``1`` to enable the Java client build.  This is disabled by default.
 - ``CMAKE_ARGS``. Additional arguments for OpenCV's CMake invocation. You can use this to make a custom build. 
 
 See the next section for more info about manual builds outside the CI environment.

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ def main():
     minimum_supported_numpy = "1.13.1"
     build_contrib = get_build_env_var_by_name("contrib")
     build_headless = get_build_env_var_by_name("headless")
+    build_java = 'ON' if get_build_env_var_by_name("java") else 'OFF'
 
     if sys.version_info[:2] >= (3, 6):
         minimum_supported_numpy = "1.13.3"
@@ -121,6 +122,8 @@ def main():
             "-DPYTHON3_LIBRARY=%s" % python_lib_path,
             "-DBUILD_opencv_python3=ON",
             "-DBUILD_opencv_python2=OFF",
+            # Disable the Java build by default as it is not needed
+            "-DBUILD_opencv_java=%s" % build_java,
             # When off, adds __init__.py and a few more helper .py's. We use our own helper files with a different structure.
             "-DOPENCV_SKIP_PYTHON_LOADER=ON",
             # Relative dir to install the built module to in the build tree.


### PR DESCRIPTION
- Java wrapper build isn't necessary for all Python builds.
- Java wrapper build can now be enabled with ``ENABLE_JAVA`` environment
  variable.