### PR TITLE
add support for building windows/arm64 package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ def main():
     )
 
     # https://stackoverflow.com/questions/1405913/python-32bit-or-64bit-mode
-    x64 = sys.maxsize > 2 ** 32
+    is64 = sys.maxsize > 2 ** 32
 
     package_name = "opencv-python"
 
@@ -88,7 +88,7 @@ def main():
     # Path regexes with forward slashes relative to CMake install dir.
     rearrange_cmake_output_data = {
         "cv2": (
-            [r"bin/opencv_videoio_ffmpeg\d{3}%s\.dll" % ("_64" if x64 else "")]
+            [r"bin/opencv_videoio_ffmpeg\d{3}%s\.dll" % ("_64" if is64 else "")]
             if os.name == "nt"
             else []
         )
@@ -130,7 +130,7 @@ def main():
     files_outside_package_dir = {"cv2": ["LICENSE.txt", "LICENSE-3RD-PARTY.txt"]}
 
     ci_cmake_generator = (
-        ["-G", "Visual Studio 14" + (" Win64" if x64 else "")]
+        ["-G", "Visual Studio 14" + (" Win64" if is64 else "")]
         if os.name == "nt"
         else ["-G", "Unix Makefiles"]
     )
@@ -164,9 +164,15 @@ def main():
             "-DBUILD_PNG=ON",
         ]
         + (
+            # CMake flags for windows/arm64 build
+            ["-DCMAKE_GENERATOR_PLATFORM=ARM64",
+             # Emulated cmake requires following flags to correctly detect
+             # target architecture for windows/arm64 build
+             "-DOPENCV_WORKAROUND_CMAKE_20989=ON",
+             "-DCMAKE_SYSTEM_PROCESSOR=ARM64"]
+            if platform.machine() == "ARM64" and sys.platform == "win32"
             # If it is not defined 'linker flags: /machine:X86' on Windows x64
-            ["-DCMAKE_GENERATOR_PLATFORM=x64"]
-            if x64 and sys.platform == "win32"
+            else ["-DCMAKE_GENERATOR_PLATFORM=x64"] if is64 and sys.platform == "win32"
             else []
           )
         + (
@@ -186,7 +192,7 @@ def main():
                 "-DWITH_MSMF=OFF"
             )  # see: https://github.com/skvark/opencv-python/issues/263
 
-    if sys.platform.startswith("linux") and not x64 and "bdist_wheel" in sys.argv:
+    if sys.platform.startswith("linux") and not is64 and "bdist_wheel" in sys.argv:
         subprocess.check_call("patch -p0 < patches/patchOpenEXR", shell=True)
 
     # OS-specific components during CI builds


### PR DESCRIPTION
This patch adds support for building windows/arm64 python package.

Python binary wheels can be created successfully with `python setup.py bdist_wheel` and passes all tests.

#### Test Results

```
python modules\python\test\test.py -v --repo .

Testing OpenCV 4.5.5
Local repo path: .
WARNING: OpenCV tests config file (opencv_python_tests.cfg) is missing, running subset of tests
Discovering python tests from: C:\users\niysai01\Workspace\opencv-python\opencv
    found 0 tests
Discovering python tests from: C:\users\niysai01\Workspace\opencv-python\opencv\modules\python\test
    found 106 tests
test_algorithm_rw (test_algorithm_rw.algorithm_rw_test) ... ok
test_async_exception (test_async.AsyncTest) ... ok
test_async_simple (test_async.AsyncTest) ... ok
....
test_umat_handle (test_umat.UMat) ... ok
test_umat_matching (test_umat.UMat) ... ok
test_umat_merge_mertens (test_umat.UMat) ... ok
test_umat_optical_flow (test_umat.UMat) ... ok
test_watershed (test_watershed.watershed_test) ... ok

----------------------------------------------------------------------
Ran 106 tests in 9.899s
```