### PR TITLE
Updated multibuild to upgrade default 64-bit test image to focal

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/opencv/opencv_contrib.git
 [submodule "multibuild"]
 	path = multibuild
-	url = https://github.com/matthew-brett/multibuild.git
+	url = https://github.com/multi-build/multibuild.git
 [submodule "opencv_extra"]
 	path = opencv_extra
 	url = https://github.com/opencv/opencv_extra.git


### PR DESCRIPTION
Updates multibuild to include https://github.com/multi-build/multibuild/pull/433

Also updates the multibuild repository URL, as it now lives at https://github.com/multi-build/multibuild/