### PR TITLE
Defined 5.x branch for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,15 @@
 [submodule "opencv"]
 	path = opencv
 	url = https://github.com/opencv/opencv.git
+	branch = 5.x
 [submodule "opencv_contrib"]
 	path = opencv_contrib
 	url = https://github.com/opencv/opencv_contrib.git
+	branch = 5.x
 [submodule "multibuild"]
 	path = multibuild
 	url = https://github.com/multi-build/multibuild.git
 [submodule "opencv_extra"]
 	path = opencv_extra
 	url = https://github.com/opencv/opencv_extra.git
+	branch = 5.x


### PR DESCRIPTION
Without this change the command `git submodule update --init --recursive --remote` use the `4.x` branch by default.