### PR TITLE
Build x64 macOS wheels for 10.13 build target

### DIFF
--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -50,7 +50,7 @@ jobs:
       SDIST: ${{ matrix.build_sdist || 0 }}
       ENABLE_HEADLESS: ${{ matrix.without_gui }}
       ENABLE_CONTRIB: ${{ matrix.with_contrib }}
-      MACOSX_DEPLOYMENT_TARGET: 10.15
+      MACOSX_DEPLOYMENT_TARGET: 10.13
     steps:
     - name: Cleanup
       run: find . -mindepth 1 -delete


### PR DESCRIPTION
Closes #714 

Unless this actually breaks functionality, I see no reason not to target these older builds, as some users are stuck on pre-10.15 macOS due to Apple's 32-bit deprecation. As I pointed out in #714, doing this passes all build tests.