### PR TITLE
Add Vulkan license text to LICENSE-3RD-PARTY.txt

### DIFF
--- a/LICENSE-3RD-PARTY.txt
+++ b/LICENSE-3RD-PARTY.txt
@@ -2436,3 +2436,21 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 Except as contained in this notice, the name of The Open Group shall not be
 used in advertising or otherwise to promote the sale, use or other dealings
 in this Software without prior written authorization from The Open Group.
+
+------------------------------------------------------------------------------
+Vulkan headers are redistributed within all opencv-python packages.
+This license applies to Vulkan headers in the directory 3rdparty/include/vulkan.
+
+Copyright (c) 2015-2018 The Khronos Group Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
It seems that the Vulkan license text is not included in the list of 3rd party licenses. I added it now for your consideration. Please let me know if it shall be included in a different way.