### PR TITLE
fix: Stop trying to use two different numpy on mac with python >= 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,6 @@ requires = [
   "numpy==1.19.3; python_version<='3.9' and sys_platform == 'linux' and platform_machine == 'aarch64'",
   "numpy==1.21.0; python_version<='3.9' and sys_platform == 'darwin' and platform_machine == 'arm64'",
   "numpy==1.19.3; python_version=='3.9' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
-  "numpy==1.21.2; python_version>='3.10' and platform_system!='Darwin''",
+  "numpy==1.21.2; python_version>='3.10' and platform_system!='Darwin'",
   "numpy==1.21.4; python_version>='3.10' and platform_system=='Darwin'"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,6 @@ requires = [
   "numpy==1.19.3; python_version<='3.9' and sys_platform == 'linux' and platform_machine == 'aarch64'",
   "numpy==1.21.0; python_version<='3.9' and sys_platform == 'darwin' and platform_machine == 'arm64'",
   "numpy==1.19.3; python_version=='3.9' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
-  "numpy==1.21.2; python_version>='3.10'",
+  "numpy==1.21.2; python_version>='3.10' and platform_system!='Darwin''",
   "numpy==1.21.4; python_version>='3.10' and platform_system=='Darwin'"
 ]


### PR DESCRIPTION
Fixes #775 