### PR TITLE
Build and release wheels for all supported python versions

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         platform: [x64]
         with_contrib: [0, 1]
         without_gui: [0, 1]

--- a/.github/workflows/build_wheels_linux_arm.yml
+++ b/.github/workflows/build_wheels_linux_arm.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         platform: [x64]
         with_contrib: [0, 1]
         without_gui: [0, 1]

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         platform: [x64]
         with_contrib: [0, 1]
         without_gui: [0, 1]

--- a/.github/workflows/build_wheels_macos_m1.yml
+++ b/.github/workflows/build_wheels_macos_m1.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         platform: [x64]
         with_contrib: [0, 1]
         without_gui: [0, 1]

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         platform: [x86, x64]
         with_contrib: [0, 1]
         without_gui: [0, 1]


### PR DESCRIPTION
The PyPI releases only have wheels for python 3.7, but 3.7-3.11 are supported and tested. This updates CI to build wheels for all of these versions, which should ease installation for users (and may help some of the other installation issues).
