### PR TITLE
Fix py38 build

### DIFF
--- a/find_version.py
+++ b/find_version.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     else:
         # local version identifier, not to be published on PyPI
         version = git_hash
-        opencv_version += ".{}".format(version)
+        opencv_version += "+{}".format(version)
 
     with open("cv2/version.py", "w") as f:
         f.write('opencv_version = "{}"\n'.format(opencv_version))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
   "scikit-build>=0.13.2",
   "numpy==1.13.3; python_version=='3.6' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
   "numpy==1.17.0; python_version=='3.7' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
-  "numpy==1.17.3; python_version=='3.8' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
+  "numpy==1.17.5; python_version=='3.8' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
   "numpy==1.19.3; python_version<='3.9' and sys_platform == 'linux' and platform_machine == 'aarch64'",
   "numpy==1.21.0; python_version<='3.9' and sys_platform == 'darwin' and platform_machine == 'arm64'",
   "numpy==1.19.3; python_version=='3.9' and platform_machine != 'aarch64' and platform_machine != 'arm64'",


### PR DESCRIPTION
fixes #836 i.e.
- ability to build untagged commits manually using `pip wheel` (ensuring the version conforms to PEP 440, and to our actual documentation, by using `+` instead of `.`)
- ability to compile against current OpenCV on Python 3.8 (using numpy 1.17.5 instead of 1.17.3 which does not compile anymore)