### PR TITLE
fix: handle None case for python library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def main():
     ]
 
     python_version = cmaker.CMaker.get_python_version()
-    python_lib_path = cmaker.CMaker.get_python_library(python_version).replace(
+    python_lib_path = (cmaker.CMaker.get_python_library(python_version) or "").replace(
         "\\", "/"
     )
     python_include_dir = cmaker.CMaker.get_python_include_dir(python_version).replace(


### PR DESCRIPTION
See https://github.com/scikit-build/scikit-build/issues/940. This was a "regression" due to this now returning "None" if the path it returns points at nothing (such as in manylinux, where the python library is intentionally removed from the docker image), but it was always allowed to return None, which makes the correct fix something like this.

Also see #837.