### PR TITLE
Fix: numpy version for python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,5 @@ requires = [
   "numpy==1.19.3; python_version=='3.9' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
   "numpy==1.21.2; python_version=='3.10' and platform_system!='Darwin'",
   "numpy==1.21.4; python_version=='3.10' and platform_system=='Darwin'",
-  "numpy==1.24.3; python_version>='3.11'"
+  "numpy==1.23.0; python_version>='3.11'"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,5 @@ requires = [
   "numpy==1.19.3; python_version=='3.9' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
   "numpy==1.21.2; python_version=='3.10' and platform_system!='Darwin'",
   "numpy==1.21.4; python_version=='3.10' and platform_system=='Darwin'",
-  "numpy==1.23.0; python_version>='3.11'"
+  "numpy==1.23.2; python_version>='3.11'"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,5 @@ requires = [
   "numpy==1.19.3; python_version=='3.9' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
   "numpy==1.21.2; python_version=='3.10' and platform_system!='Darwin'",
   "numpy==1.21.4; python_version=='3.10' and platform_system=='Darwin'",
-  "numpy==1.22.0; python_version>='3.11'"
+  "numpy==1.24.3; python_version>='3.11'"
 ]

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def main():
         'numpy>=1.19.3; python_version>="3.6" and platform_system=="Linux" and platform_machine=="aarch64"',
         'numpy>=1.21.0; python_version<="3.9" and platform_system=="Darwin" and platform_machine=="arm64"',
         'numpy>=1.21.4; python_version>="3.10" and platform_system=="Darwin"',
-        "numpy>=1.22.0; python_version>='3.11'"
+        "numpy>=1.24.3; python_version>='3.11'"
     ]
 
     python_version = cmaker.CMaker.get_python_version()

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def main():
         'numpy>=1.19.3; python_version>="3.6" and platform_system=="Linux" and platform_machine=="aarch64"',
         'numpy>=1.21.0; python_version<="3.9" and platform_system=="Darwin" and platform_machine=="arm64"',
         'numpy>=1.21.4; python_version>="3.10" and platform_system=="Darwin"',
-        "numpy>=1.24.3; python_version>='3.11'"
+        "numpy>=1.23.5; python_version>='3.11'"
     ]
 
     python_version = cmaker.CMaker.get_python_version()


### PR DESCRIPTION
Fix for issue #835

I encountered the same issue today. By updating to require numpy 1.24.3 I was about to build successfully for my environment (python 3.11.3 / macos ventura arm64 / gstreamer support enabled)