### PR TITLE
Change setup.py to trigger GitHub show dependents

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,7 @@ import subprocess
 import re
 import sysconfig
 import platform
-import skbuild
-from skbuild import cmaker
+from skbuild import cmaker, setup
 
 
 def main():
@@ -264,7 +263,7 @@ def main():
         rearrange_cmake_output_data, files_outside_package_dir, package_data.keys()
     )
 
-    skbuild.setup(
+    setup(
         name=package_name,
         version=package_version,
         url="https://github.com/opencv/opencv-python",


### PR DESCRIPTION
Currently, GitHub cannot parse `setup.py` to detect dependencies/dependents (so no Used By section appears like in https://github.com/numpy/numpy).

Goal of this PR is to use a common syntax for `setuptools` with `setup`. Perhaps, GitHub ignores `skbuild`

Current SBOM from https://github.com/opencv/opencv-python/network/dependencies: 
[opencv-python_opencv_7cfd1ee8ecc52f9466af29b63440703fc635011b.json](https://github.com/opencv/opencv-python/files/13623291/opencv-python_opencv_7cfd1ee8ecc52f9466af29b63440703fc635011b.json)
