### PR TITLE
Until NumPy 2.0 is supported, it might be nice to specify numpy<2 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,16 +23,16 @@ def main():
     build_rolling = get_build_env_var_by_name("rolling")
 
     install_requires = [
-        'numpy>=1.13.3; python_version<"3.7"',
-        'numpy>=1.17.0; python_version>="3.7"', # https://github.com/numpy/numpy/pull/13725
-        'numpy>=1.17.3; python_version>="3.8"',
-        'numpy>=1.19.3; python_version>="3.9"',
-        'numpy>=1.21.2; python_version>="3.10"',
-        'numpy>=1.19.3; python_version>="3.6" and platform_system=="Linux" and platform_machine=="aarch64"',
-        'numpy>=1.21.0; python_version<="3.9" and platform_system=="Darwin" and platform_machine=="arm64"',
-        'numpy>=1.21.4; python_version>="3.10" and platform_system=="Darwin"',
-        "numpy>=1.23.5; python_version>='3.11'",
-        "numpy>=1.26.0; python_version>='3.12'"
+        'numpy>=1.13.3,<2; python_version<"3.7"',
+        'numpy>=1.17.0,<2; python_version>="3.7"', # https://github.com/numpy/numpy/pull/13725
+        'numpy>=1.17.3,<2; python_version>="3.8"',
+        'numpy>=1.19.3,<2; python_version>="3.9"',
+        'numpy>=1.21.2,<2; python_version>="3.10"',
+        'numpy>=1.19.3,<2; python_version>="3.6" and platform_system=="Linux" and platform_machine=="aarch64"',
+        'numpy>=1.21.0,<2; python_version<="3.9" and platform_system=="Darwin" and platform_machine=="arm64"',
+        'numpy>=1.21.4,<2; python_version>="3.10" and platform_system=="Darwin"',
+        "numpy>=1.23.5,<2; python_version>='3.11'",
+        "numpy>=1.26.0,<2; python_version>='3.12'"
     ]
 
     python_version = cmaker.CMaker.get_python_version()


### PR DESCRIPTION
Until a longer term solution is found to make opencv-python compatible with numpy 2.0, it might be nice to add `numpy>=xxx,<2` in setup.py. This can facilitate, for example, installation via pip and CI/CD in downstream libraries that depend opencv-python.