### PR TITLE
Support python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,5 +9,5 @@ requires = [
   "numpy>=2.0.0;  python_version>='3.9'",
   "pip",
   "scikit-build>=0.14.0",
-  "setuptools==59.2.0",
+  "setuptools>=59.2.0",
 ]


### PR DESCRIPTION
Currently, opencv-python fails to build under python 3.12. This patch fixes that problem by permitting the use of any setuptools>=59.2.0, rather than mandating that specific version.

This patch fixes #988. See discussion there for details.

I have tested by successfully installing opencv-python.