### PR TITLE
fix: add CMake as a build requirement only if required

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include README.md
 include find_version.py
 include setup.py
 include pyproject.toml
+include _build_backend/backend.py
 recursive-include cv2 *
 recursive-include docker *
 recursive-include opencv *

--- a/_build_backend/backend.py
+++ b/_build_backend/backend.py
@@ -1,0 +1,23 @@
+from setuptools import build_meta as _orig
+
+prepare_metadata_for_build_wheel = _orig.prepare_metadata_for_build_wheel
+build_wheel = _orig.build_wheel
+build_sdist = _orig.build_sdist
+get_requires_for_build_sdist = _orig.get_requires_for_build_sdist
+
+def get_requires_for_build_wheel(config_settings=None):
+    from packaging import version
+    from skbuild.exceptions import SKBuildError
+    from skbuild.cmaker import get_cmake_version
+    packages = _orig.get_requires_for_build_wheel(config_settings)
+    # check if system cmake can be used if present
+    # if not, append cmake PyPI distribution to required packages
+    # scikit-build>=0.18 itself requires cmake 3.5+
+    min_version = "3.5"
+    try:
+        if version.parse(get_cmake_version().split("-")[0]) < version.parse(min_version):
+            packages.append(f'cmake>={min_version}')
+    except SKBuildError:
+        packages.append(f'cmake>={min_version}')
+
+    return packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,17 @@
 [build-system]
 requires = [
-  "cmake>=3.1",
   "numpy==1.13.3; python_version=='3.6' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
   "numpy==1.17.0; python_version=='3.7' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
   "numpy==1.17.5; python_version=='3.8' and platform_machine != 'aarch64' and platform_machine != 'arm64'",
   "numpy==1.19.3; python_version<'3.9' and sys_platform == 'linux' and platform_machine == 'aarch64'",
   "numpy==1.21.0; python_version<'3.9' and sys_platform == 'darwin' and platform_machine == 'arm64'",
   "numpy>=2.0.0;  python_version>='3.9'",
+  "packaging",
   "pip",
   "scikit-build>=0.14.0",
   "setuptools==59.2.0",
 ]
+# use a custom backend to manage CMake check / installation
+# see https://scikit-build.readthedocs.io/en/latest/usage.html#adding-cmake-as-building-requirement-only-if-not-installed-or-too-low-a-version
+build-backend = "backend"
+backend-path = ["_build_backend"]


### PR DESCRIPTION
The PyPI distribution of CMake shall not be listed as an unconditional build requirement. It shall only be added as a build requirement if not installed or too low a version.

This helps building from sources on platforms where no wheels are available for CMake but the system already provides a recent enough CMake version. Adress the comment in https://github.com/opencv/opencv-python/issues/793#issuecomment-1436843424.

In case of error checking the version, the backend falls back to using the PyPI distribution of CMake.