### PR TITLE
Disable limited API for free-threaded Python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -191,7 +191,7 @@ def main():
             "-DBUILD_TESTS=OFF",
             "-DBUILD_PERF_TESTS=OFF",
             "-DBUILD_DOCS=OFF",
-            "-DPYTHON3_LIMITED_API=ON",
+            "-DPYTHON3_LIMITED_API=%s" % ("OFF" if sysconfig.get_config_var("Py_GIL_DISABLED") else "ON"),
             "-DBUILD_OPENEXR=ON",
         ]
         + (


### PR DESCRIPTION
Free-threaded Python does not support the Limited C API.[^1]

This PR should make it possible to build OpenCV wheels for Python 3.13t (https://github.com/opencv/opencv-python/issues/1029).

[^1]: https://docs.python.org/3/howto/free-threading-extensions.html#limited-c-api-and-stable-abi