### PR TITLE
Update Mac x86 to macos-13 as macos-12 is deprecated  by Github actions and will be removed soon

### DIFF
--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   Build:
-    runs-on: macos-12
+    runs-on: macos-13
     defaults:
       run:
         shell: bash
@@ -98,7 +98,7 @@ jobs:
 
   Test:
     needs: [Build]
-    runs-on: macos-12
+    runs-on: macos-13
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Motivation: https://github.com/actions/runner-images/issues/10721