### PR TITLE
Add NASM assembler to Windows build for jpeg-turbo.

### DIFF
--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -59,6 +59,8 @@ jobs:
         architecture: ${{ matrix.platform }}
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.1
+    - name: Setup NASM
+      uses: ilammy/setup-nasm@v1
     - name: Build a package
       # CMake 3.25 regression fix. See https://stackoverflow.com/questions/74162633/problem-compiling-from-source-opencv-with-mvsc2019-in-64-bit-version
       run: |


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv-python/issues/1058