### PR TITLE
Add Python `3.13` in the supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Python 3.x compatible pre-built wheels are provided for the officially supported
 - 3.10
 - 3.11
 - 3.12
+- 3.13
 
 ### Backward compatibility
 


### PR DESCRIPTION
I think this is essential for people to know that python `3.13` wheels are provided pre-built by openCV.

This should be added in #1074 but the author might have forgot this minor stuff too 😀