### PR TITLE
Updated Windows build environment to 2025. 2019 - retired.

### DIFF
--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   Build:
-    runs-on: windows-2019
+    runs-on: windows-2025
     strategy:
       fail-fast: false
       matrix:
@@ -48,7 +48,7 @@ jobs:
           echo "ENABLE_ROLLING=1" >> $GITHUB_ENV
         fi
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: false
         fetch-depth: 0
@@ -79,7 +79,7 @@ jobs:
 
   Test:
     needs: [Build]
-    runs-on: windows-2019
+    runs-on: windows-2025
     defaults:
       run:
         shell: cmd
@@ -95,6 +95,7 @@ jobs:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       OPENCV_TEST_DATA_PATH: ${{ github.workspace }}\opencv_extra\testdata
       PYLINT_TEST_FILE: ${{ github.workspace }}\opencv\samples\python\squares.py
+      PlatformToolset: v143
     steps:
     - name: Cleanup
       shell: bash
@@ -103,7 +104,7 @@ jobs:
         rm -rf ./.??* || true
       working-directory: ${{ github.workspace }}
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
         fetch-depth: 0

--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,7 @@ def main():
     files_outside_package_dir = {"cv2": ["LICENSE.txt", "LICENSE-3RD-PARTY.txt"]}
 
     ci_cmake_generator = (
-        ["-G", "Visual Studio 14" + (" Win64" if is64 else "")]
+        ["-G", "Visual Studio 17 2022"]
         if os.name == "nt"
         else ["-G", "Unix Makefiles"]
     )


### PR DESCRIPTION
https://wiki.python.org/moin/WindowsCompilers
Replaces: https://github.com/opencv/opencv-python/pull/1105