### PR TITLE
Relax the build dependency on NumPy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 [build-system]
 requires = [
   "numpy<2.0; python_version<'3.9'",
-  "numpy==2.0.2; python_version>='3.9' and python_version<'3.13'",
-  "numpy==2.1.3; python_version=='3.13'",
+  # NumPy >=1.25 defaults to exposing "an API that is backwards compatible with the oldest NumPy version that supports the currently oldest compatible Python version"
+  # https://numpy.org/devdocs/dev/depending_on_numpy.html#adding-a-dependency-on-numpy
+  "numpy>=2.0; python_version>='3.9'",
   "packaging",
   "pip",
   "scikit-build>=0.14.0",


### PR DESCRIPTION
Do not pin NumPy build dependencies to specific versions.  It is no longer necessary since NumPy 1.25, as it automatically exposes "an API that is backwards compatible with the oldest NumPy version that supports the currently oldest compatible Python version" -- effectively removing the need to maintain downstream compatibility matrices.

See: https://numpy.org/devdocs/dev/depending_on_numpy.html#adding-a-dependency-on-numpy