### PR TITLE
Fixed project naming to generate proper sdist archive names.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,16 +73,16 @@ def main():
     # https://stackoverflow.com/questions/1405913/python-32bit-or-64bit-mode
     is64 = sys.maxsize > 2 ** 32
 
-    package_name = "opencv-python"
+    package_name = "opencv_python"
 
     if build_contrib and not build_headless:
-        package_name = "opencv-contrib-python"
+        package_name = "opencv_contrib_python"
 
     if build_contrib and build_headless:
-        package_name = "opencv-contrib-python-headless"
+        package_name = "opencv_contrib_python_headless"
 
     if build_headless and not build_contrib:
-        package_name = "opencv-python-headless"
+        package_name = "opencv_python_headless"
 
     if build_rolling:
         package_name += "-rolling"


### PR DESCRIPTION
Fixes
```
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
         Filename 'opencv-python-4.13.0.92.tar.gz' is invalid, should be        
         'opencv_python-4.13.0.92.tar.gz'.                                      
```