### PR TITLE
Add Python 3.14 to macOS ARM64 build matrix

### DIFF
--- a/.github/workflows/build_wheels_macos_m1.yml
+++ b/.github/workflows/build_wheels_macos_m1.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.9','3.10','3.11','3.12','3.13','3.14']
         platform: [x64]
         with_contrib: [0, 1]
         without_gui: [0, 1]


### PR DESCRIPTION
This PR add python 3.14 to macOS ARM64 build matrix.
Currently macOS ARM64 build wheels only using python 3.9 while the test matrix already include python 3.14.

Fixes #1196 