### PR TITLE
Fix Windows builds for 5.x branch.

### DIFF
--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   Build:
-    runs-on: windows-2025
+    runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:
@@ -65,7 +65,7 @@ jobs:
         python --version
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools
-        python -m pip install cmake==3.24.2
+        python -m pip install cmake==4.3.2
         python -m pip install toml && python -c "import toml; c = toml.load('pyproject.toml'); print('\n'.join(c['build-system']['requires']))" >> requirements.txt | python -m pip install -r requirements.txt
         set "CI_BUILD=1" && python setup.py bdist_wheel --py-limited-api=cp37 --dist-dir=%cd%\wheelhouse -v
       shell: cmd
@@ -77,14 +77,14 @@ jobs:
 
   Test:
     needs: [Build]
-    runs-on: windows-2025
+    runs-on: windows-2022
     defaults:
       run:
         shell: cmd
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         platform: [x86, x64]
         with_contrib: [0, 1]
         without_gui: [0, 1]

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -62,6 +62,7 @@ jobs:
     - name: Build a package
       # CMake 3.25 regression fix. See https://stackoverflow.com/questions/74162633/problem-compiling-from-source-opencv-with-mvsc2019-in-64-bit-version
       run: |
+        set PATH=C:\Users\runneradmin\nasm\;%PATH%
         python --version
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools
@@ -100,7 +101,6 @@ jobs:
       run: |
         rm -rf ./* || true
         rm -rf ./.??* || true
-        mv C:/mingw64/bin/cc.exe C:/mingw64/bin/cc.exe.qqq
       working-directory: ${{ github.workspace }}
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -62,7 +62,6 @@ jobs:
     - name: Build a package
       # CMake 3.25 regression fix. See https://stackoverflow.com/questions/74162633/problem-compiling-from-source-opencv-with-mvsc2019-in-64-bit-version
       run: |
-        set PATH=C:\Users\runneradmin\nasm\;%PATH%
         python --version
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -57,8 +57,8 @@ jobs:
         architecture: ${{ matrix.platform }}
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.1
-    - name: Setup NASM
-      uses: ilammy/setup-nasm@v1
+    # - name: Setup NASM
+    #   uses: ilammy/setup-nasm@v1
     - name: Build a package
       # CMake 3.25 regression fix. See https://stackoverflow.com/questions/74162633/problem-compiling-from-source-opencv-with-mvsc2019-in-64-bit-version
       run: |

--- a/.github/workflows/build_wheels_windows.yml
+++ b/.github/workflows/build_wheels_windows.yml
@@ -57,8 +57,8 @@ jobs:
         architecture: ${{ matrix.platform }}
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.1
-    # - name: Setup NASM
-    #   uses: ilammy/setup-nasm@v1
+    - name: Setup NASM
+      uses: ilammy/setup-nasm@v1
     - name: Build a package
       # CMake 3.25 regression fix. See https://stackoverflow.com/questions/74162633/problem-compiling-from-source-opencv-with-mvsc2019-in-64-bit-version
       run: |
@@ -100,6 +100,7 @@ jobs:
       run: |
         rm -rf ./* || true
         rm -rf ./.??* || true
+        mv C:/mingw64/bin/cc.exe C:/mingw64/bin/cc.exe.qqq
       working-directory: ${{ github.workspace }}
     - name: Checkout
       uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -147,8 +147,11 @@ def main():
     # Raw paths relative to sourcetree root.
     files_outside_package_dir = {"cv2": ["LICENSE.txt", "LICENSE-3RD-PARTY.txt"]}
 
+    # HACK: Disabled generic assembler for now.
+    # Windows 2025 CI environment does not provide suitable assembler or build is broken in OpenCV MLAS.
     ci_cmake_generator = (
-        ["-G", "Visual Studio 17 2022"]
+        ["-G", "Visual Studio 17 2022",
+         "-DCMAKE_ASM_COMPILER="]
         if os.name == "nt"
         else ["-G", "Unix Makefiles"]
     )


### PR DESCRIPTION
Switch to windows-2022 build env as MS VS 2022 is used by default for now.
See https://github.com/actions/runner-images/issues/14017