### PR TITLE
Numpy package update for testing on Linux

### DIFF
--- a/.github/workflows/build_wheels_manylinux.yml
+++ b/.github/workflows/build_wheels_manylinux.yml
@@ -103,8 +103,9 @@ jobs:
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       MB_PYTHON_VERSION: ${{ matrix.python-version }}
-      NP_TEST_DEP: numpy==1.19.4
-      NP_TEST_DEP_LATEST: numpy==2.2.6
+      NP_TEST_DEP_OLD: numpy==1.19.4
+      NP_TEST_DEP: numpy==2.2.6
+      NP_TEST_DEP_LATEST: numpy==2.5.0
       CONFIG_PATH: travis_config.sh
       PLAT: ${{ matrix.platform }}
       SDIST: ${{ matrix.build_sdist || 0 }}
@@ -122,7 +123,16 @@ jobs:
         fetch-depth: 0
 
     - name: Setup Environment variables
-      run: if [ "3.10" == "${{ matrix.python-version }}" -o "3.11" == "${{ matrix.python-version }}" -o "3.12" == "${{ matrix.python-version }}" -o "3.13" == "${{ matrix.python-version }}" -o "3.14" == "${{ matrix.python-version }}" ]; then echo "TEST_DEPENDS=$(echo $NP_TEST_DEP_LATEST)" >> $GITHUB_ENV; else echo "TEST_DEPENDS=$(echo $NP_TEST_DEP)" >> $GITHUB_ENV; fi
+      run: |
+        if [ "3.8" == "${{ matrix.python-version }}" -o "3.9" == "${{ matrix.python-version }}" ]
+        then
+            echo "TEST_DEPENDS=$(echo $NP_TEST_DEP_OLD)" >> $GITHUB_ENV
+        elif [ "3.10" == "${{ matrix.python-version }}" -o "3.11" == "${{ matrix.python-version }}" -o "3.12" == "${{ matrix.python-version }}" -o "3.13" == "${{ matrix.python-version }}" ]
+        then
+            echo "TEST_DEPENDS=$(echo $NP_TEST_DEP)" >> $GITHUB_ENV
+        else
+            echo "TEST_DEPENDS=$(echo $NP_TEST_DEP_LATEST)" >> $GITHUB_ENV
+        fi
     - name: Download a wheel accordingly to matrix
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
Previous numpy 2.26 cases issue:
```
======================================================================
ERROR: test_correctImage (test_ccm.photo_test.test_correctImage)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.14/dist-packages/numpy/testing/_private/utils.py", line 851, in assert_array_compare
    val = comparison(x, y)
  File "/usr/local/lib/python3.14/dist-packages/numpy/testing/_private/utils.py", line 1710, in compare
    return np._core.numeric.isclose(x, y, rtol=rtol, atol=atol,
           ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                   equal_nan=equal_nan)
                                   ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/dist-packages/numpy/_core/numeric.py", line 2447, in isclose
    result = (less_equal(abs(x-y), atol + rtol * abs(y))
                             ~^~
ValueError: operands could not be broadcast together with shapes (1250100,) (0,) 

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opencv/modules/python/test/test_ccm.py", line 272, in test_correctImage
    np.testing.assert_allclose(gold_img, calibratedImage, rtol=0.1, atol=0.1)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/dist-packages/numpy/testing/_private/utils.py", line 1715, in assert_allclose
    assert_array_compare(compare, actual, desired, err_msg=str(err_msg),
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                         verbose=verbose, header=header, equal_nan=equal_nan,
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                         strict=strict)
                         ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/dist-packages/numpy/testing/_private/utils.py", line 929, in assert_array_compare
    raise ValueError(msg)
```

The issue is reproducible with particular versions combination of python and numpy and looks like Numpy bug.
Most probable reason: https://github.com/numpy/numpy/issues/28681